### PR TITLE
Define default open icon for frontend loader

### DIFF
--- a/ai-chatbot-pro/includes/class-frontend-loader.php
+++ b/ai-chatbot-pro/includes/class-frontend-loader.php
@@ -78,8 +78,9 @@ class AICP_Frontend_Loader {
         wp_enqueue_script('aicp-chatbot-script', AICP_PLUGIN_URL . 'assets/js/chatbot.js', ['jquery'], AICP_VERSION, true);
 
         // Lógica de avatares
-        $default_bot_avatar = AICP_PLUGIN_URL . 'assets/bot-default-avatar.png';
+        $default_bot_avatar  = AICP_PLUGIN_URL . 'assets/bot-default-avatar.png';
         $default_user_avatar = AICP_PLUGIN_URL . 'assets/user-default-avatar.png';
+        $default_open_icon   = 'data:image/svg+xml;base64,' . base64_encode('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white"><path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z"/></svg>');
 
         $bot_avatar = !empty($s['bot_avatar_url']) ? esc_url($s['bot_avatar_url']) : $default_bot_avatar;
         $user_avatar = !empty($s['user_avatar_url']) ? esc_url($s['user_avatar_url']) : $default_user_avatar;
@@ -109,7 +110,7 @@ class AICP_Frontend_Loader {
             'bot_avatar' => $bot_avatar,
             'user_avatar' => $user_avatar,
             'position' => $s['position'] ?? 'br',
-            'open_icon' => !empty($s['open_icon_url']) ? esc_url($s['open_icon_url']) : $default_bot_avatar,
+            'open_icon' => !empty($s['open_icon_url']) ? esc_url($s['open_icon_url']) : $default_open_icon,
             'suggested_messages' => $suggested_messages,
             'lead_auto_collect'  => $lead_auto_collect,
 


### PR DESCRIPTION
## Summary
- add default inline SVG open icon for frontend assets
- use new default when no open icon URL provided

## Testing
- `php -l ai-chatbot-pro/includes/class-frontend-loader.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c128fb5864833083c603d07c7df891