### PR TITLE
Sanitize and expose quick replies

### DIFF
--- a/ai-chatbot-pro/admin/assistant-meta-boxes.php
+++ b/ai-chatbot-pro/admin/assistant-meta-boxes.php
@@ -294,8 +294,8 @@ function aicp_save_meta_box_data($post_id) {
     $current['objective'] = isset($s['objective']) ? sanitize_textarea_field($s['objective']) : '';
     $current['length_tone'] = isset($s['length_tone']) ? sanitize_textarea_field($s['length_tone']) : '';
     $current['example'] = isset($s['example']) ? sanitize_textarea_field($s['example']) : '';
-    if (isset($s['suggested_messages']) && is_array($s['suggested_messages'])) { 
-        $current['suggested_messages'] = array_map('sanitize_text_field', $s['suggested_messages']); 
+    if (isset($s['suggested_messages']) && is_array($s['suggested_messages'])) {
+        $current['suggested_messages'] = array_filter(array_map('sanitize_text_field', $s['suggested_messages']));
     }
 
     // Diseño

--- a/ai-chatbot-pro/assets/js/chatbot.js
+++ b/ai-chatbot-pro/assets/js/chatbot.js
@@ -103,13 +103,13 @@ jQuery(function($) {
 
 function renderSuggestedReplies() {
         const $container = $('.aicp-suggested-replies');
-        if (!params.suggested_messages || params.suggested_messages.length === 0) {
+        if (!params.quick_replies || params.quick_replies.length === 0) {
             $container.hide();
             return;
         }
         $container.empty();
-        params.suggested_messages.forEach(msg => {
-            if(msg) {
+        params.quick_replies.forEach(msg => {
+            if (msg) {
                 const $button = $('<button class="aicp-suggested-reply"></button>').text(msg);
                 $container.append($button);
             }

--- a/ai-chatbot-pro/includes/class-frontend-loader.php
+++ b/ai-chatbot-pro/includes/class-frontend-loader.php
@@ -89,10 +89,7 @@ class AICP_Frontend_Loader {
         }
 
         // Obtener mensajes sugeridos
-        $suggested_messages = [];
-        if (!empty($s['suggested_messages'])) {
-            $suggested_messages = array_filter(array_map('trim', explode("\n", $s['suggested_messages'])));
-        }
+        $quick_replies = array_filter(array_map('sanitize_text_field', $s['suggested_messages'] ?? []));
 
         // Obtener configuración de detección de leads
 
@@ -110,7 +107,7 @@ class AICP_Frontend_Loader {
             'user_avatar' => $user_avatar,
             'position' => $s['position'] ?? 'br',
             'open_icon' => !empty($s['open_icon_url']) ? esc_url($s['open_icon_url']) : $default_bot_avatar,
-            'suggested_messages' => $suggested_messages,
+            'quick_replies'     => $quick_replies,
             'lead_auto_collect'  => $lead_auto_collect,
 
 

--- a/ai-chatbot-pro/includes/class-shortcode-handler.php
+++ b/ai-chatbot-pro/includes/class-shortcode-handler.php
@@ -74,7 +74,7 @@ class AICP_Shortcode_Handler {
             $user_avatar = get_avatar_url(get_current_user_id(), ['size' => 96]);
         }
         
-        $suggested_messages = array_filter($s['suggested_messages'] ?? []);
+        $quick_replies = array_filter(array_map('sanitize_text_field', $s['suggested_messages'] ?? []));
         
         wp_localize_script('aicp-chatbot-script', 'aicp_chatbot_params', [
             'ajax_url'           => admin_url('admin-ajax.php'),
@@ -86,7 +86,7 @@ class AICP_Shortcode_Handler {
             'user_avatar'        => $user_avatar,
             'open_icon'          => $open_icon,
             'position'           => $s['position'] ?? 'br',
-            'suggested_messages' => $suggested_messages,
+            'quick_replies'      => $quick_replies,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- Sanitize `suggested_messages` and save as an array in assistant settings
- Sanitize and expose quick replies in frontend loaders
- Update chatbot script to consume `params.quick_replies`

## Testing
- `php -l includes/class-shortcode-handler.php`
- `php -l includes/class-frontend-loader.php`
- `php -l admin/assistant-meta-boxes.php`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c128fc4e20833095e1c4dc3fc91ae1