### PR TITLE
Use wp_json_encode for conversation and lead data

### DIFF
--- a/ai-chatbot-pro/includes/class-ajax-handler.php
+++ b/ai-chatbot-pro/includes/class-ajax-handler.php
@@ -39,7 +39,7 @@ class AICP_Ajax_Handler {
             'assistant_id'     => $assistant_id,
             'session_id'       => $session_id,
             'timestamp'        => current_time('mysql'),
-            'conversation_log' => json_encode($conversation, JSON_UNESCAPED_UNICODE)
+            'conversation_log' => wp_json_encode($conversation, JSON_UNESCAPED_UNICODE)
         ];
         $format = ['%d', '%s', '%s', '%s'];
         
@@ -50,7 +50,7 @@ class AICP_Ajax_Handler {
 
         if (!empty($lead_data)) {
             $data['has_lead'] = 1;
-            $data['lead_data'] = json_encode($lead_data, JSON_UNESCAPED_UNICODE);
+            $data['lead_data'] = wp_json_encode($lead_data, JSON_UNESCAPED_UNICODE);
             $format[] = '%d';
             $format[] = '%s';
         }


### PR DESCRIPTION
## Summary
- Use `wp_json_encode` instead of `json_encode` for storing conversation logs
- Use `wp_json_encode` for lead data storage to maintain WordPress encoding behavior

## Testing
- `php -l ai-chatbot-pro/includes/class-ajax-handler.php`

------
https://chatgpt.com/codex/tasks/task_e_68c128fce07083308a7770000369502e