### PR TITLE
Reset post data after training search loop

### DIFF
--- a/ai-chatbot-pro/includes/class-training-handler.php
+++ b/ai-chatbot-pro/includes/class-training-handler.php
@@ -43,9 +43,10 @@ class AICP_Training_Handler {
                 // Usamos el objeto $post directamente para mayor estabilidad en AJAX
                 $content = wp_strip_all_tags($post->post_content);
                 $content = preg_replace('/\s+/', ' ', $content); // Reemplazar múltiples espacios/saltos de línea con uno solo
-                
+
                 $context .= "Título: " . esc_html($post->post_title) . "\nContenido: " . $content . "\n\n---\n\n";
             }
+            wp_reset_postdata();
         }
         
         // Limitar la longitud total del contexto para no exceder los límites del prompt


### PR DESCRIPTION
## Summary
- reset global post data after iterating over training search results

## Testing
- `php -l ai-chatbot-pro/includes/class-training-handler.php`
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*
- `phpcs ai-chatbot-pro/includes/class-training-handler.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c128fda8748330b9546084a1392076