### PR TITLE
Compile assistant templates and enqueue in admin

### DIFF
--- a/ai-chatbot-pro/admin/assistant-meta-boxes.php
+++ b/ai-chatbot-pro/admin/assistant-meta-boxes.php
@@ -41,7 +41,9 @@ function aicp_admin_scripts($hook) {
         wp_enqueue_style('wp-color-picker');
         wp_enqueue_style('aicp-admin-styles', AICP_PLUGIN_URL . 'assets/css/admin.css', [], AICP_VERSION);
         wp_enqueue_style('aicp-chatbot-preview-styles', AICP_PLUGIN_URL . 'assets/css/chatbot.css', [], AICP_VERSION);
-        wp_enqueue_script('aicp-admin-script', AICP_PLUGIN_URL . 'assets/js/admin-scripts.js', ['jquery', 'wp-color-picker'], AICP_VERSION, true);
+        wp_register_script('aicp-templates', AICP_PLUGIN_URL . 'templates/templates.js', [], AICP_VERSION, true);
+        wp_enqueue_script('aicp-templates');
+        wp_enqueue_script('aicp-admin-script', AICP_PLUGIN_URL . 'assets/js/admin-scripts.js', ['jquery', 'wp-color-picker', 'aicp-templates'], AICP_VERSION, true);
         
         $settings = get_post_meta($post->ID, '_aicp_assistant_settings', true);
         if (!is_array($settings)) $settings = [];

--- a/ai-chatbot-pro/package.json
+++ b/ai-chatbot-pro/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ai-chatbot-pro",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/ai-chatbot-pro/templates/templates.js
+++ b/ai-chatbot-pro/templates/templates.js
@@ -1,0 +1,11 @@
+"use strict";
+var ASSISTANT_TEMPLATES = {
+    greeting: '<p>Hola, {{name}}!</p>'
+};
+function renderTemplate(name, data) {
+    if (data === void 0) { data = {}; }
+    var template = ASSISTANT_TEMPLATES[name] || '';
+    return template.replace(/{{\s*(\w+)\s*}}/g, function (_, key) { var _a; return String((_a = data[key]) !== null && _a !== void 0 ? _a : ''); });
+}
+window.ASSISTANT_TEMPLATES = ASSISTANT_TEMPLATES;
+window.renderTemplate = renderTemplate;

--- a/ai-chatbot-pro/templates/templates.ts
+++ b/ai-chatbot-pro/templates/templates.ts
@@ -1,0 +1,13 @@
+interface TemplatesMap { [key: string]: string; }
+
+const ASSISTANT_TEMPLATES: TemplatesMap = {
+  greeting: '<p>Hola, {{name}}!</p>'
+};
+
+function renderTemplate(name: string, data: Record<string, any> = {}): string {
+  const template = ASSISTANT_TEMPLATES[name] || '';
+  return template.replace(/{{\s*(\w+)\s*}}/g, (_, key) => String(data[key] ?? ''));
+}
+
+(window as any).ASSISTANT_TEMPLATES = ASSISTANT_TEMPLATES;
+(window as any).renderTemplate = renderTemplate;

--- a/ai-chatbot-pro/tsconfig.json
+++ b/ai-chatbot-pro/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "none",
+    "strict": true
+  },
+  "files": ["templates/templates.ts"]
+}


### PR DESCRIPTION
## Summary
- build templates.js from TypeScript and expose ASSISTANT_TEMPLATES and renderTemplate globally
- load templates.js before admin-scripts in assistant meta boxes
- add TypeScript build configuration

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/typescript)*
- `npm run build`
- `php -l admin/assistant-meta-boxes.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1290022e08330aab7b4ec83a60962