### PR TITLE
Add template rendering helper and migration system prompt

### DIFF
--- a/ai-chatbot-pro/assistant_templates.json
+++ b/ai-chatbot-pro/assistant_templates.json
@@ -1,0 +1,3 @@
+{
+  "default": "{{persona}}\n\nOBJETIVO: {{objective}}\n\nTONO: {{length_tone}}\n\nEJEMPLO: {{example}}"
+}

--- a/ai-chatbot-pro/includes/migration.php
+++ b/ai-chatbot-pro/includes/migration.php
@@ -1,0 +1,18 @@
+<?php
+
+require_once __DIR__ . '/template-functions.php';
+
+$templates_path = dirname(__DIR__) . '/assistant_templates.json';
+$templates = [];
+if (file_exists($templates_path)) {
+    $json = file_get_contents($templates_path);
+    $templates = json_decode($json, true);
+}
+
+if (!function_exists('aicp_render_template') || empty($templates)) {
+    return;
+}
+
+$template_key = isset($meta['template']) ? $meta['template'] : 'default';
+$template = $templates[$template_key] ?? '';
+$system_prompt = $template ? aicp_render_template($template, $meta) : '';

--- a/ai-chatbot-pro/includes/template-functions.php
+++ b/ai-chatbot-pro/includes/template-functions.php
@@ -1,0 +1,19 @@
+<?php
+
+if (!function_exists('aicp_render_template')) {
+    /**
+     * Render a string template by replacing {{placeholders}} with metadata values.
+     *
+     * @param string $tpl  The template string containing placeholders.
+     * @param array  $meta Associative array of values used for interpolation.
+     *
+     * @return string The interpolated template.
+     */
+    function aicp_render_template($tpl, $meta)
+    {
+        return preg_replace_callback('/{{\s*(.+?)\s*}}/', function ($matches) use ($meta) {
+            $key = $matches[1];
+            return array_key_exists($key, $meta) ? $meta[$key] : '';
+        }, $tpl);
+    }
+}


### PR DESCRIPTION
## Summary
- add `aicp_render_template` helper to interpolate placeholders
- load `assistant_templates.json` during migration and generate `system_prompt`
- ensure migration validates template function and loaded templates before rendering

## Testing
- `php -l ai-chatbot-pro/includes/template-functions.php`
- `php -l ai-chatbot-pro/includes/migration.php`
- `jq . ai-chatbot-pro/assistant_templates.json`


------
https://chatgpt.com/codex/tasks/task_e_68c1290144c48330be2d404ba1437aff