### PR TITLE
Rename suggested messages to quick replies

### DIFF
--- a/ai-chatbot-pro/admin/assistant-meta-boxes.php
+++ b/ai-chatbot-pro/admin/assistant-meta-boxes.php
@@ -123,7 +123,7 @@ function aicp_render_instructions_tab($v) {
         <tr><th><label for="aicp_objective"><?php _e('Objetivo Principal', 'ai-chatbot-pro'); ?></label></th><td><textarea name="aicp_settings[objective]" id="aicp_objective" rows="2" class="large-text"><?php echo esc_textarea($v['objective'] ?? 'Mi objetivo es ayudar a los usuarios a encontrar la información que necesitan y animarles a contactar para obtener un presupuesto.'); ?></textarea></td></tr>
         <tr><th><label for="aicp_length_tone"><?php _e('Longitud y Tono', 'ai-chatbot-pro'); ?></label></th><td><textarea name="aicp_settings[length_tone]" id="aicp_length_tone" rows="3" class="large-text"><?php echo esc_textarea($v['length_tone'] ?? 'Intenta ser lo más concisa posible, manteniendo un tono amable y profesional.'); ?></textarea></td></tr>
         <tr><th><label for="aicp_example"><?php _e('Ejemplo de Respuesta', 'ai-chatbot-pro'); ?></label></th><td><textarea name="aicp_settings[example]" id="aicp_example" rows="5" class="large-text"><?php echo esc_textarea($v['example'] ?? 'Si el cliente pregunta por el precio de una web, responde: "El precio de una web puede variar mucho, pero para darte una idea, nuestros proyectos suelen empezar en 1.500€. ¿Te gustaría que te preparásemos un presupuesto detallado sin compromiso?"'); ?></textarea></td></tr>
-        <tr><th><label><?php _e('Mensajes Sugeridos', 'ai-chatbot-pro'); ?></label></th><td><input type="text" name="aicp_settings[suggested_messages][]" value="<?php echo esc_attr($v['suggested_messages'][0] ?? ''); ?>" class="large-text" placeholder="<?php _e('Ej: Me interesa el servicio de SEO', 'ai-chatbot-pro'); ?>"><br><input type="text" name="aicp_settings[suggested_messages][]" value="<?php echo esc_attr($v['suggested_messages'][1] ?? ''); ?>" class="large-text" placeholder="<?php _e('Ej: Quiero una web económica', 'ai-chatbot-pro'); ?>"><br><input type="text" name="aicp_settings[suggested_messages][]" value="<?php echo esc_attr($v['suggested_messages'][2] ?? ''); ?>" class="large-text" placeholder="<?php _e('Ej: ¿Podéis llamarme?', 'ai-chatbot-pro'); ?>"><p class="description"><?php _e('Estos mensajes aparecerán como botones clicables para el usuario.', 'ai-chatbot-pro'); ?></p></td></tr>
+        <tr><th><label><?php _e('Respuestas Rápidas', 'ai-chatbot-pro'); ?></label></th><td><input type="text" name="aicp_settings[quick_replies][]" value="<?php echo esc_attr($v['quick_replies'][0] ?? ''); ?>" class="large-text" placeholder="<?php _e('Ej: Me interesa el servicio de SEO', 'ai-chatbot-pro'); ?>"><br><input type="text" name="aicp_settings[quick_replies][]" value="<?php echo esc_attr($v['quick_replies'][1] ?? ''); ?>" class="large-text" placeholder="<?php _e('Ej: Quiero una web económica', 'ai-chatbot-pro'); ?>"><br><input type="text" name="aicp_settings[quick_replies][]" value="<?php echo esc_attr($v['quick_replies'][2] ?? ''); ?>" class="large-text" placeholder="<?php _e('Ej: ¿Podéis llamarme?', 'ai-chatbot-pro'); ?>"><p class="description"><?php _e('Estas respuestas aparecerán como botones clicables para el usuario.', 'ai-chatbot-pro'); ?></p></td></tr>
     </table>
     <?php
 }
@@ -294,8 +294,8 @@ function aicp_save_meta_box_data($post_id) {
     $current['objective'] = isset($s['objective']) ? sanitize_textarea_field($s['objective']) : '';
     $current['length_tone'] = isset($s['length_tone']) ? sanitize_textarea_field($s['length_tone']) : '';
     $current['example'] = isset($s['example']) ? sanitize_textarea_field($s['example']) : '';
-    if (isset($s['suggested_messages']) && is_array($s['suggested_messages'])) { 
-        $current['suggested_messages'] = array_map('sanitize_text_field', $s['suggested_messages']); 
+    if (isset($s['quick_replies']) && is_array($s['quick_replies'])) {
+        $current['quick_replies'] = array_map('sanitize_text_field', $s['quick_replies']);
     }
 
     // Diseño

--- a/ai-chatbot-pro/assets/css/chatbot.css
+++ b/ai-chatbot-pro/assets/css/chatbot.css
@@ -80,10 +80,10 @@
 .aicp-bot-thinking .typing-dot:nth-child(3) { animation-delay: 0.3s; }
 @keyframes typing-bounce { 0%, 80%, 100% { transform: scale(0); } 40% { transform: scale(1.0); } }
 
-/* Mensajes Sugeridos */
-.aicp-suggested-replies { padding: 0 15px 10px; flex-shrink: 0; display: flex; flex-wrap: wrap; gap: 8px; }
-.aicp-suggested-reply { background-color: #fff; border: 1px solid #ccc; border-radius: 20px; padding: 6px 12px; font-size: 0.85em; cursor: pointer; transition: background-color 0.2s; }
-.aicp-suggested-reply:hover { background-color: #e9e9e9; }
+/* Respuestas Rápidas */
+.aicp-quick-replies { padding: 0 15px 10px; flex-shrink: 0; display: flex; flex-wrap: wrap; gap: 8px; }
+.aicp-quick-reply { background-color: #fff; border: 1px solid #ccc; border-radius: 20px; padding: 6px 12px; font-size: 0.85em; cursor: pointer; transition: background-color 0.2s; }
+.aicp-quick-reply:hover { background-color: #e9e9e9; }
 
 /* Pie de página */
 .aicp-chat-footer { padding: 10px 15px; background: #fff; border-top: 1px solid #e0e0e0; flex-shrink: 0; }

--- a/ai-chatbot-pro/assets/js/chatbot.js
+++ b/ai-chatbot-pro/assets/js/chatbot.js
@@ -83,7 +83,7 @@ jQuery(function($) {
                 <div class="aicp-header-title">${params.header_title}</div>
             </div>
             <div class="aicp-chat-body"></div>
-              <div class="aicp-suggested-replies"></div>
+              <div class="aicp-quick-replies"></div>
               <div class="aicp-chat-footer">
                 <form id="aicp-chat-form">
                     <input type="text" id="aicp-chat-input" placeholder="Escribe un mensaje..." autocomplete="off">
@@ -97,20 +97,20 @@ jQuery(function($) {
         </button>
         `;
         $('#aicp-chatbot-container').addClass(`position-${params.position}`).html(chatbotHTML);
-          renderSuggestedReplies();
+          renderQuickReplies();
         $('#aicp-capture-lead-btn').remove();
     }
 
-function renderSuggestedReplies() {
-        const $container = $('.aicp-suggested-replies');
-        if (!params.suggested_messages || params.suggested_messages.length === 0) {
+function renderQuickReplies() {
+        const $container = $('.aicp-quick-replies');
+        if (!params.quick_replies || params.quick_replies.length === 0) {
             $container.hide();
             return;
         }
         $container.empty();
-        params.suggested_messages.forEach(msg => {
+        params.quick_replies.forEach(msg => {
             if(msg) {
-                const $button = $('<button class="aicp-suggested-reply"></button>').text(msg);
+                const $button = $('<button class="aicp-quick-reply"></button>').text(msg);
                 $container.append($button);
             }
         });
@@ -306,7 +306,7 @@ function renderSuggestedReplies() {
 
         conversationHistory.push({ role: 'user', content: message });
         addMessageToChat('user', message);
-        $('.aicp-suggested-replies').slideUp();
+        $('.aicp-quick-replies').slideUp();
 
         if (isFarewell(message)) {
             return;
@@ -382,7 +382,7 @@ function renderSuggestedReplies() {
         }
     }
     
-    function handleSuggestedReplyClick() {
+    function handleQuickReplyClick() {
         const message = $(this).text();
         sendMessage(message);
     }
@@ -440,7 +440,7 @@ function renderSuggestedReplies() {
         buildChatHTML();
         $(document).on('click', '#aicp-chat-toggle-button', toggleChatWindow);
         $(document).on('submit', '#aicp-chat-form', handleFormSubmit);
-        $(document).on('click', '.aicp-suggested-reply', handleSuggestedReplyClick);
+        $(document).on('click', '.aicp-quick-reply', handleQuickReplyClick);
         $(document).on('click', '.aicp-feedback-btn', handleFeedbackClick);
         $(document).on('click', '.aicp-calendar-link', handleCalendarClick);
         

--- a/ai-chatbot-pro/includes/class-frontend-loader.php
+++ b/ai-chatbot-pro/includes/class-frontend-loader.php
@@ -88,10 +88,10 @@ class AICP_Frontend_Loader {
             $user_avatar = get_avatar_url(get_current_user_id(), ['size' => 96]);
         }
 
-        // Obtener mensajes sugeridos
-        $suggested_messages = [];
-        if (!empty($s['suggested_messages'])) {
-            $suggested_messages = array_filter(array_map('trim', explode("\n", $s['suggested_messages'])));
+        // Obtener respuestas rápidas
+        $quick_replies = [];
+        if (!empty($s['quick_replies'])) {
+            $quick_replies = array_filter(array_map('trim', explode("\n", $s['quick_replies'])));
         }
 
         // Obtener configuración de detección de leads
@@ -110,7 +110,7 @@ class AICP_Frontend_Loader {
             'user_avatar' => $user_avatar,
             'position' => $s['position'] ?? 'br',
             'open_icon' => !empty($s['open_icon_url']) ? esc_url($s['open_icon_url']) : $default_bot_avatar,
-            'suggested_messages' => $suggested_messages,
+            'quick_replies' => $quick_replies,
             'lead_auto_collect'  => $lead_auto_collect,
 
 

--- a/ai-chatbot-pro/includes/class-shortcode-handler.php
+++ b/ai-chatbot-pro/includes/class-shortcode-handler.php
@@ -74,7 +74,7 @@ class AICP_Shortcode_Handler {
             $user_avatar = get_avatar_url(get_current_user_id(), ['size' => 96]);
         }
         
-        $suggested_messages = array_filter($s['suggested_messages'] ?? []);
+        $quick_replies = array_filter($s['quick_replies'] ?? []);
         
         wp_localize_script('aicp-chatbot-script', 'aicp_chatbot_params', [
             'ajax_url'           => admin_url('admin-ajax.php'),
@@ -86,7 +86,7 @@ class AICP_Shortcode_Handler {
             'user_avatar'        => $user_avatar,
             'open_icon'          => $open_icon,
             'position'           => $s['position'] ?? 'br',
-            'suggested_messages' => $suggested_messages,
+            'quick_replies' => $quick_replies,
         ]);
     }
 

--- a/ai-chatbot-pro/languages/ai-chatbot-pro.pot
+++ b/ai-chatbot-pro/languages/ai-chatbot-pro.pot
@@ -122,24 +122,24 @@ msgstr ""
 msgid "Ejemplo de Respuesta"
 msgstr ""
 
-#: ai-chatbot-pro/admin/assistant-meta-boxes.php:105
-msgid "Mensajes Sugeridos"
+#: ai-chatbot-pro/admin/assistant-meta-boxes.php:126
+msgid "Respuestas Rápidas"
 msgstr ""
 
-#: ai-chatbot-pro/admin/assistant-meta-boxes.php:105
+#: ai-chatbot-pro/admin/assistant-meta-boxes.php:126
 msgid "Ej: Me interesa el servicio de SEO"
 msgstr ""
 
-#: ai-chatbot-pro/admin/assistant-meta-boxes.php:105
+#: ai-chatbot-pro/admin/assistant-meta-boxes.php:126
 msgid "Ej: Quiero una web económica"
 msgstr ""
 
-#: ai-chatbot-pro/admin/assistant-meta-boxes.php:105
+#: ai-chatbot-pro/admin/assistant-meta-boxes.php:126
 msgid "Ej: ¿Podéis llamarme?"
 msgstr ""
 
-#: ai-chatbot-pro/admin/assistant-meta-boxes.php:105
-msgid "Estos mensajes aparecerán como botones clicables para el usuario."
+#: ai-chatbot-pro/admin/assistant-meta-boxes.php:126
+msgid "Estas respuestas aparecerán como botones clicables para el usuario."
 msgstr ""
 
 #: ai-chatbot-pro/admin/assistant-meta-boxes.php:107


### PR DESCRIPTION
## Summary
- rename suggested messages to quick replies in settings and data handling
- update frontend to render quick replies with new CSS classes
- refresh translation template for quick reply terminology

## Testing
- `php -l admin/assistant-meta-boxes.php`
- `php -l includes/class-shortcode-handler.php`
- `php -l includes/class-frontend-loader.php`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c12903a0d08330b061a2f128ecb350