### PR TITLE
Add assistant template selection and prompt generation

### DIFF
--- a/ai-chatbot-pro/admin/assistant-meta-boxes.php
+++ b/ai-chatbot-pro/admin/assistant-meta-boxes.php
@@ -44,7 +44,7 @@ function aicp_admin_scripts($hook) {
         wp_register_script('aicp-templates', AICP_PLUGIN_URL . 'templates/templates.js', [], AICP_VERSION, true);
         wp_enqueue_script('aicp-templates');
         wp_enqueue_script('aicp-admin-script', AICP_PLUGIN_URL . 'assets/js/admin-scripts.js', ['jquery', 'wp-color-picker', 'aicp-templates'], AICP_VERSION, true);
-        
+
         $settings = get_post_meta($post->ID, '_aicp_assistant_settings', true);
         if (!is_array($settings)) $settings = [];
 
@@ -69,6 +69,7 @@ function aicp_admin_scripts($hook) {
             'default_bot_avatar' => $default_bot_avatar,
             'default_user_avatar' => $default_user_avatar,
             'default_open_icon' => $default_open_icon,
+            'templates_url' => AICP_PLUGIN_URL . 'assistant_templates.json',
             'initial_settings' => [
                 'bot_avatar_url' => $settings['bot_avatar_url'] ?? $default_bot_avatar,
                 'user_avatar_url' => $settings['user_avatar_url'] ?? $default_user_avatar,
@@ -79,6 +80,7 @@ function aicp_admin_scripts($hook) {
                 'color_bot_text' => $settings['color_bot_text'] ?? '#333333',
                 'color_user_bg' => $settings['color_user_bg'] ?? '#dcf8c6',
                 'color_user_text' => $settings['color_user_text'] ?? '#000000',
+                'template_id' => $settings['template_id'] ?? '',
             ],
             'meta' => $meta,
         ]);
@@ -129,6 +131,7 @@ function aicp_render_main_meta_box($post) {
 function aicp_render_instructions_tab($v) {
     ?>
     <table class="form-table">
+        <tr><th><label for="aicp_template_id"><?php _e('Plantilla de Asistente', 'ai-chatbot-pro'); ?></label></th><td><select name="aicp_settings[template_id]" id="aicp_template_id" class="regular-text"><option value=""><?php _e('Personalizado', 'ai-chatbot-pro'); ?></option></select><p class="description"><?php _e('Selecciona una plantilla predefinida para autocompletar los campos.', 'ai-chatbot-pro'); ?></p></td></tr>
         <tr><th><label for="aicp_model"><?php _e('Modelo de IA', 'ai-chatbot-pro'); ?></label></th><td><select name="aicp_settings[model]" id="aicp_model" class="regular-text"><option value="gpt-4o" <?php selected($v['model'] ?? 'gpt-4o', 'gpt-4o'); ?>>GPT-4o</option><option value="gpt-4-turbo-preview" <?php selected($v['model'] ?? '', 'gpt-4-turbo-preview'); ?>>GPT-4 Turbo</option></select></td></tr>
         <tr><th><label for="aicp_persona"><?php _e('Nombre y Personalidad', 'ai-chatbot-pro'); ?></label></th><td><textarea name="aicp_settings[persona]" id="aicp_persona" rows="3" class="large-text"><?php echo esc_textarea($v['persona'] ?? 'Te llamas Ana, eres una asistente virtual experta en marketing digital.'); ?></textarea></td></tr>
         <tr><th><label for="aicp_objective"><?php _e('Objetivo Principal', 'ai-chatbot-pro'); ?></label></th><td><textarea name="aicp_settings[objective]" id="aicp_objective" rows="2" class="large-text"><?php echo esc_textarea($v['objective'] ?? 'Mi objetivo es ayudar a los usuarios a encontrar la información que necesitan y animarles a contactar para obtener un presupuesto.'); ?></textarea></td></tr>
@@ -305,6 +308,7 @@ function aicp_save_meta_box_data($post_id) {
     $current['objective'] = isset($s['objective']) ? sanitize_textarea_field($s['objective']) : '';
     $current['length_tone'] = isset($s['length_tone']) ? sanitize_textarea_field($s['length_tone']) : '';
     $current['example'] = isset($s['example']) ? sanitize_textarea_field($s['example']) : '';
+    $current['template_id'] = isset($s['template_id']) ? sanitize_text_field($s['template_id']) : '';
 
     if (isset($s['quick_replies']) && is_array($s['quick_replies'])) {
         $current['quick_replies'] = array_map('sanitize_text_field', $s['quick_replies']);

--- a/ai-chatbot-pro/assets/js/admin-scripts.js
+++ b/ai-chatbot-pro/assets/js/admin-scripts.js
@@ -214,6 +214,33 @@ jQuery(function($) {
         $('#aicp_position').on('change', function() { $('#aicp-preview-chatbot-container').removeClass('position-br position-bl').addClass('position-' + $(this).val()); });
     }
 
+    function initTemplateSelector() {
+        if (typeof loadAssistantTemplates !== 'function') return;
+        loadAssistantTemplates(aicp_admin_params.templates_url).then(function(templates) {
+            const $select = $('#aicp_template_id');
+            templates.forEach(t => {
+                $select.append(`<option value="${t.id}">${t.label}</option>`);
+            });
+            const selected = aicp_admin_params.initial_settings.template_id || '';
+            if (selected) {
+                $select.val(selected);
+            }
+            $select.on('change', function() {
+                const tmpl = templates.find(t => t.id === this.value);
+                if (!tmpl) return;
+                $('#aicp_persona').val(tmpl.persona || '');
+                $('#aicp_objective').val(tmpl.objective || '');
+                $('#aicp_length_tone').val(tmpl.length_tone || '');
+                $('#aicp_example').val(tmpl.example || '');
+                if (Array.isArray(tmpl.quick_replies)) {
+                    $('input[name="aicp_settings[quick_replies][]"]').each(function(index) {
+                        $(this).val(tmpl.quick_replies[index] || '');
+                    });
+                }
+            });
+        });
+    }
+
     if ($('body').hasClass('post-type-aicp_assistant')) {
         handleTabs();
         handleMediaUploader();
@@ -222,6 +249,7 @@ jQuery(function($) {
         handleLeadQuestions();
         initLivePreview();
         handleDeleteLogFromList();
+        initTemplateSelector();
 
     }
 });

--- a/ai-chatbot-pro/includes/class-ajax-handler.php
+++ b/ai-chatbot-pro/includes/class-ajax-handler.php
@@ -92,20 +92,61 @@ class AICP_Ajax_Handler {
             wp_send_json_error(['message' => __('La API Key de OpenAI no está configurada.', 'ai-chatbot-pro')]); 
         }
         
-        $system_prompt_parts = [];
-        if (!empty($s['persona'])) $system_prompt_parts[] = "PERSONALIDAD: " . $s['persona'];
-        if (!empty($s['objective'])) $system_prompt_parts[] = "OBJETIVO PRINCIPAL: " . $s['objective'];
-        if (!empty($s['length_tone'])) $system_prompt_parts[] = "TONO Y LONGITUD: " . $s['length_tone'];
-        if (!empty($s['example'])) $system_prompt_parts[] = "EJEMPLO DE RESPUESTA: " . $s['example'];
-        
-        // Se añade el contexto de la página al prompt del sistema
-        if (!empty($page_context)) {
-            $system_prompt_parts[] = "--- INICIO DEL CONTEXTO DE LA PÁGINA ACTUAL ---\n" . $page_context . "\n--- FIN DEL CONTEXTO ---";
-            $system_prompt_parts[] = "Responde a las preguntas del usuario basándote en el contexto de la página proporcionado. Si la información no está en el contexto, indícalo amablemente.";
+        $system_prompt = '';
+        $template_id = $s['template_id'] ?? '';
+        if ($template_id) {
+            $templates_json = @file_get_contents(AICP_PLUGIN_DIR . 'assistant_templates.json');
+            $templates = $templates_json ? json_decode($templates_json, true) : [];
+            if (is_array($templates)) {
+                foreach ($templates as $tpl) {
+                    if (($tpl['id'] ?? '') === $template_id) {
+                        $variables = [
+                            'brand' => sanitize_text_field(get_option('aicp_brand', '')),
+                            'services' => array_map('sanitize_text_field', (array) get_option('aicp_services', [])),
+                            'pricing_ranges' => array_map('sanitize_text_field', (array) get_option('aicp_pricing_ranges', [])),
+                            'timezone' => sanitize_text_field(wp_timezone_string()),
+                        ];
+                        $template_prompt = $tpl['system_prompt_template'] ?? '';
+                        $system_prompt = preg_replace_callback('/{{\s*([a-zA-Z0-9_\.]+)\s*}}/', function($m) use ($variables) {
+                            $keys = explode('.', $m[1]);
+                            $value = $variables;
+                            foreach ($keys as $k) {
+                                if (is_array($value) && isset($value[$k])) {
+                                    $value = $value[$k];
+                                } else {
+                                    $value = '';
+                                    break;
+                                }
+                            }
+                            if (is_array($value)) $value = implode(', ', $value);
+                            return $value;
+                        }, $template_prompt);
+                        if (!empty($page_context)) {
+                            $system_prompt .= "\n\n--- INICIO DEL CONTEXTO DE LA PÁGINA ACTUAL ---\n" . $page_context . "\n--- FIN DEL CONTEXTO ---";
+                            $system_prompt .= "\nResponde a las preguntas del usuario basándote en el contexto de la página proporcionado. Si la información no está en el contexto, indícalo amablemente.";
+                        }
+                        break;
+                    }
+                }
+            }
         }
 
-        $system_prompt = implode("\n\n", $system_prompt_parts);
-        if(empty($system_prompt)) $system_prompt = 'Eres un asistente de IA.';
+        if (empty($system_prompt)) {
+            $system_prompt_parts = [];
+            if (!empty($s['persona'])) $system_prompt_parts[] = "PERSONALIDAD: " . $s['persona'];
+            if (!empty($s['objective'])) $system_prompt_parts[] = "OBJETIVO PRINCIPAL: " . $s['objective'];
+            if (!empty($s['length_tone'])) $system_prompt_parts[] = "TONO Y LONGITUD: " . $s['length_tone'];
+            if (!empty($s['example'])) $system_prompt_parts[] = "EJEMPLO DE RESPUESTA: " . $s['example'];
+
+            // Se añade el contexto de la página al prompt del sistema
+            if (!empty($page_context)) {
+                $system_prompt_parts[] = "--- INICIO DEL CONTEXTO DE LA PÁGINA ACTUAL ---\n" . $page_context . "\n--- FIN DEL CONTEXTO ---";
+                $system_prompt_parts[] = "Responde a las preguntas del usuario basándote en el contexto de la página proporcionado. Si la información no está en el contexto, indícalo amablemente.";
+            }
+
+            $system_prompt = implode("\n\n", $system_prompt_parts);
+            if(empty($system_prompt)) $system_prompt = 'Eres un asistente de IA.';
+        }
         
         $short_term_memory = array_slice($history, -4);
         $conversation = [['role' => 'system', 'content' => $system_prompt]];

--- a/ai-chatbot-pro/templates/templates.js
+++ b/ai-chatbot-pro/templates/templates.js
@@ -1,11 +1,28 @@
 "use strict";
-var ASSISTANT_TEMPLATES = {
-    greeting: '<p>Hola, {{name}}!</p>'
-};
-function renderTemplate(name, data) {
+var ASSISTANT_TEMPLATES = [];
+function loadAssistantTemplates(url) {
+    return fetch(url)
+        .then(function (res) { return res.json(); })
+        .then(function (data) {
+        ASSISTANT_TEMPLATES = data;
+        window.ASSISTANT_TEMPLATES = ASSISTANT_TEMPLATES;
+        return ASSISTANT_TEMPLATES;
+    });
+}
+function renderTemplate(template, data) {
     if (data === void 0) { data = {}; }
-    var template = ASSISTANT_TEMPLATES[name] || '';
-    return template.replace(/{{\s*(\w+)\s*}}/g, function (_, key) { var _a; return String((_a = data[key]) !== null && _a !== void 0 ? _a : ''); });
+    return template.replace(/{{\s*([\w\.]+)\s*}}/g, function (_, key) {
+        var parts = key.split('.');
+        var value = data;
+        for (var _i = 0, parts_1 = parts; _i < parts_1.length; _i++) {
+            var part = parts_1[_i];
+            value = value === null || value === void 0 ? void 0 : value[part];
+            if (value === undefined || value === null)
+                return '';
+        }
+        return String(value);
+    });
 }
 window.ASSISTANT_TEMPLATES = ASSISTANT_TEMPLATES;
+window.loadAssistantTemplates = loadAssistantTemplates;
 window.renderTemplate = renderTemplate;

--- a/ai-chatbot-pro/templates/templates.ts
+++ b/ai-chatbot-pro/templates/templates.ts
@@ -1,13 +1,41 @@
-interface TemplatesMap { [key: string]: string; }
+interface AssistantTemplate {
+  id: string;
+  label: string;
+  description: string;
+  variables: string[];
+  system_prompt_template: string;
+  quick_replies: string[];
+  examples_by_intent?: { [key: string]: string };
+  persona?: string;
+  objective?: string;
+  length_tone?: string;
+  example?: string;
+}
 
-const ASSISTANT_TEMPLATES: TemplatesMap = {
-  greeting: '<p>Hola, {{name}}!</p>'
-};
+let ASSISTANT_TEMPLATES: AssistantTemplate[] = [];
 
-function renderTemplate(name: string, data: Record<string, any> = {}): string {
-  const template = ASSISTANT_TEMPLATES[name] || '';
-  return template.replace(/{{\s*(\w+)\s*}}/g, (_, key) => String(data[key] ?? ''));
+function loadAssistantTemplates(url: string): Promise<AssistantTemplate[]> {
+  return fetch(url)
+    .then(res => res.json())
+    .then((data: AssistantTemplate[]) => {
+      ASSISTANT_TEMPLATES = data;
+      (window as any).ASSISTANT_TEMPLATES = ASSISTANT_TEMPLATES;
+      return ASSISTANT_TEMPLATES;
+    });
+}
+
+function renderTemplate(template: string, data: Record<string, any> = {}): string {
+  return template.replace(/{{\s*([\w\.]+)\s*}}/g, (_, key) => {
+    const parts = key.split('.');
+    let value: any = data;
+    for (const part of parts) {
+      value = value?.[part];
+      if (value === undefined || value === null) return '';
+    }
+    return String(value);
+  });
 }
 
 (window as any).ASSISTANT_TEMPLATES = ASSISTANT_TEMPLATES;
+(window as any).loadAssistantTemplates = loadAssistantTemplates;
 (window as any).renderTemplate = renderTemplate;


### PR DESCRIPTION
## Summary
- add assistant template selector to assistant meta box with template persistence
- load template definitions in admin scripts to prefill instruction fields
- generate system prompts from selected template in AJAX handler and expose loader in templates module

## Testing
- `npm run build`
- `php -l admin/assistant-meta-boxes.php`
- `php -l includes/class-ajax-handler.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1375e6ca88330b6bd685f59abb205