### PR TITLE
Handle quick replies as array

### DIFF
--- a/ai-chatbot-pro/assets/js/chatbot.js
+++ b/ai-chatbot-pro/assets/js/chatbot.js
@@ -5,6 +5,7 @@
 jQuery(function($) {
     const params = window.aicp_chatbot_params;
     if (!params) return;
+    params.quick_replies = Array.isArray(params.quick_replies) ? params.quick_replies : [];
 
     let conversationHistory = [];
     let logId = 0;

--- a/ai-chatbot-pro/includes/class-frontend-loader.php
+++ b/ai-chatbot-pro/includes/class-frontend-loader.php
@@ -92,8 +92,8 @@ class AICP_Frontend_Loader {
 
         // Obtener respuestas rápidas
         $quick_replies = [];
-        if (!empty($s['quick_replies'])) {
-            $quick_replies = array_filter(array_map('trim', explode("\n", $s['quick_replies'])));
+        if (!empty($s['quick_replies']) && is_array($s['quick_replies'])) {
+            $quick_replies = array_map('trim', $s['quick_replies']);
         }
 
 


### PR DESCRIPTION
## Summary
- Parse quick replies directly as arrays in frontend loader and add default empty array
- Ensure chatbot script always provides an array of quick replies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `php tests/test-prompt-builder.php`


------
https://chatgpt.com/codex/tasks/task_e_68c13d8551c88330a78fb6ffa355dc14