### PR TITLE
Use default open icon in frontend loader

### DIFF
--- a/ai-chatbot-pro/includes/class-frontend-loader.php
+++ b/ai-chatbot-pro/includes/class-frontend-loader.php
@@ -113,7 +113,7 @@ class AICP_Frontend_Loader {
             'user_avatar' => $user_avatar,
             'position' => $s['position'] ?? 'br',
 
-            'open_icon' => !empty($s['open_icon_url']) ? esc_url($s['open_icon_url']) : $default_bot_avatar,
+            'open_icon' => !empty($s['open_icon_url']) ? esc_url($s['open_icon_url']) : $default_open_icon,
 
             'quick_replies' => $quick_replies,
 


### PR DESCRIPTION
## Summary
- fix open icon fallback in frontend loader to use dedicated default icon
- confirm admin script preview links open icon settings

## Testing
- `php -l ai-chatbot-pro/includes/class-frontend-loader.php`
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c13d89955c8330a7632d44fa8ccf5f