### PR TITLE
Add template selector for assistant instructions

### DIFF
--- a/ai-chatbot-pro/admin/assistant-meta-boxes.php
+++ b/ai-chatbot-pro/admin/assistant-meta-boxes.php
@@ -146,6 +146,15 @@ function aicp_render_instructions_tab($v) {
             </td>
         </tr>
 
+        <tr>
+            <th><label for="aicp_template_id"><?php _e('Plantilla', 'ai-chatbot-pro'); ?></label></th>
+            <td>
+                <select name="aicp_settings[template_id]" id="aicp_template_id">
+                    <option value=""><?php _e('Selecciona una plantilla', 'ai-chatbot-pro'); ?></option>
+                </select>
+            </td>
+        </tr>
+
         <tr><th><label for="aicp_persona"><?php _e('Nombre y Personalidad', 'ai-chatbot-pro'); ?></label></th><td><textarea name="aicp_settings[persona]" id="aicp_persona" rows="3" class="large-text"><?php echo esc_textarea($v['persona'] ?? 'Te llamas Ana, eres una asistente virtual experta en marketing digital.'); ?></textarea></td></tr>
         <tr><th><label for="aicp_objective"><?php _e('Objetivo Principal', 'ai-chatbot-pro'); ?></label></th><td><textarea name="aicp_settings[objective]" id="aicp_objective" rows="2" class="large-text"><?php echo esc_textarea($v['objective'] ?? 'Mi objetivo es ayudar a los usuarios a encontrar la información que necesitan y animarles a contactar para obtener un presupuesto.'); ?></textarea></td></tr>
         <tr><th><label for="aicp_length_tone"><?php _e('Longitud y Tono', 'ai-chatbot-pro'); ?></label></th><td><textarea name="aicp_settings[length_tone]" id="aicp_length_tone" rows="3" class="large-text"><?php echo esc_textarea($v['length_tone'] ?? 'Intenta ser lo más concisa posible, manteniendo un tono amable y profesional.'); ?></textarea></td></tr>


### PR DESCRIPTION
## Summary
- add "Plantilla" selector to assistant instruction settings
- persist chosen template ID in `_aicp_assistant_settings`
- rely on existing admin script to populate templates dynamically

## Testing
- `php -l ai-chatbot-pro/admin/assistant-meta-boxes.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c13d83f54c8330b780defc37e07856