### PR TITLE
Compile assistant prompt and allow manual override

### DIFF
--- a/ai-chatbot-pro/assets/js/admin-scripts.js
+++ b/ai-chatbot-pro/assets/js/admin-scripts.js
@@ -165,6 +165,20 @@ jQuery(function($) {
         });
     }
 
+    function handleCustomPromptToggle() {
+        const $textarea = $('#aicp_custom_prompt');
+        const $toggle = $('#aicp_edit_prompt_toggle');
+        function refresh() {
+            if ($toggle.is(':checked')) {
+                $textarea.prop('readonly', false);
+            } else {
+                $textarea.prop('readonly', true);
+            }
+        }
+        $toggle.on('change', refresh);
+        refresh();
+    }
+
 
     function handleLivePreview(element, value) {
         const $el = $(element);
@@ -250,6 +264,7 @@ jQuery(function($) {
         initLivePreview();
         handleDeleteLogFromList();
         initTemplateSelector();
+        handleCustomPromptToggle();
 
     }
 });

--- a/ai-chatbot-pro/includes/class-prompt-builder.php
+++ b/ai-chatbot-pro/includes/class-prompt-builder.php
@@ -23,6 +23,10 @@ class AICP_Prompt_Builder {
     }
 
     public static function build($settings, $page_context = '') {
+        if (!empty($settings['custom_prompt'])) {
+            return $settings['custom_prompt'];
+        }
+
         $parts = [];
 
         $template_id = $settings['template_id'] ?? '';

--- a/tests/test-prompt-builder.php
+++ b/tests/test-prompt-builder.php
@@ -41,4 +41,11 @@ $settings2 = [
 $prompt2 = AICP_Prompt_Builder::build($settings2);
 assert(str_contains($prompt2, 'Eres asistente de ACME para e-commerce'));
 
+// Test with custom prompt
+$settings3 = [
+    'custom_prompt' => 'USAR ESTE PROMPT',
+];
+$prompt3 = AICP_Prompt_Builder::build($settings3);
+assert($prompt3 === 'USAR ESTE PROMPT');
+
 echo "All tests passed\n";


### PR DESCRIPTION
## Summary
- Build and store assistant system prompt on save, with optional manual override in the Instructions tab
- Teach `AICP_Prompt_Builder` to honor a saved custom prompt
- Add admin UI & JS toggle to edit the generated prompt and test coverage for custom prompts

## Testing
- `php tests/test-prompt-builder.php`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c13d84903c83309e866db5eee55a02