### PR TITLE
Fix admin scripts loading on new assistant pages

### DIFF
--- a/ai-chatbot-pro/admin/assistant-meta-boxes.php
+++ b/ai-chatbot-pro/admin/assistant-meta-boxes.php
@@ -50,60 +50,81 @@ function aicp_force_template_change_event() {
  */
 function aicp_admin_scripts($hook) {
     global $post;
-    if (($hook == 'post-new.php' || $hook == 'post.php') && isset($post->post_type) && 'aicp_assistant' === $post->post_type) {
-        wp_enqueue_media();
-        wp_enqueue_style('wp-color-picker');
-        wp_enqueue_style('aicp-admin-styles', AICP_PLUGIN_URL . 'assets/css/admin.css', [], AICP_VERSION);
-        wp_enqueue_style('aicp-chatbot-preview-styles', AICP_PLUGIN_URL . 'assets/css/chatbot.css', [], AICP_VERSION);
-        wp_register_script('aicp-templates', AICP_PLUGIN_URL . 'templates/templates.js', [], AICP_VERSION, true);
-        wp_enqueue_script('aicp-templates');
-        wp_enqueue_script('aicp-admin-script', AICP_PLUGIN_URL . 'assets/js/admin-scripts.js', ['jquery', 'wp-color-picker', 'aicp-templates'], AICP_VERSION, true);
 
-        $settings = get_post_meta($post->ID, '_aicp_assistant_settings', true);
-        if (!is_array($settings)) $settings = [];
+    $is_edit_screen = false;
+    $post_id = 0;
 
-        $default_bot_avatar  = AICP_PLUGIN_URL . 'assets/bot-default-avatar.png';
-        $default_user_avatar = AICP_PLUGIN_URL . 'assets/user-default-avatar.png';
-        $default_open_icon   = 'data:image/svg+xml;base64,' . base64_encode('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white"><path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z"/></svg>');
-
-        $meta = [
-            'brand' => sanitize_text_field(get_option('aicp_brand', '')),
-            'domain' => sanitize_text_field(get_option('aicp_domain', '')),
-            'services' => array_map('sanitize_text_field', (array) get_option('aicp_services', [])),
-            'pricing_ranges' => array_map('sanitize_text_field', (array) get_option('aicp_pricing_ranges', [])),
-            'timezone' => sanitize_text_field(wp_timezone_string()),
-        ];
-
-        wp_localize_script('aicp-admin-script', 'aicp_admin_params', [
-            'ajax_url' => admin_url('admin-ajax.php'),
-            'assistant_id' => $post->ID,
-            'delete_nonce' => wp_create_nonce('aicp_delete_log_nonce'),
-            'get_log_nonce' => wp_create_nonce('aicp_get_log_nonce'),
-            'capture_lead_nonce' => wp_create_nonce('aicp_capture_lead_nonce'),
-            'default_bot_avatar' => $default_bot_avatar,
-            'default_user_avatar' => $default_user_avatar,
-            'default_open_icon' => $default_open_icon,
-            'templates_url' => AICP_PLUGIN_URL . 'assistant_templates.json',
-            'initial_settings' => [
-                'bot_avatar_url' => $settings['bot_avatar_url'] ?? $default_bot_avatar,
-                'user_avatar_url' => $settings['user_avatar_url'] ?? $default_user_avatar,
-                'open_icon_url' => $settings['open_icon_url'] ?? $default_open_icon,
-                'position' => $settings['position'] ?? 'br',
-                'color_primary' => $settings['color_primary'] ?? '#0073aa',
-                'color_bot_bg' => $settings['color_bot_bg'] ?? '#ffffff',
-                'color_bot_text' => $settings['color_bot_text'] ?? '#333333',
-                'color_user_bg' => $settings['color_user_bg'] ?? '#dcf8c6',
-                'color_user_text' => $settings['color_user_text'] ?? '#000000',
-                'template_id' => $settings['template_id'] ?? '',
-                'persona' => $settings['persona'] ?? '',
-                'objective' => $settings['objective'] ?? '',
-                'length_tone' => $settings['length_tone'] ?? '',
-                'example' => $settings['example'] ?? '',
-                'quick_replies' => $settings['quick_replies'] ?? [],
-            ],
-            'meta' => $meta,
-        ]);
+    if ($hook === 'post.php' && isset($post->post_type) && 'aicp_assistant' === $post->post_type) {
+        $is_edit_screen = true;
+        $post_id = (int) $post->ID;
+    } elseif ($hook === 'post-new.php') {
+        $requested_type = isset($_GET['post_type']) ? sanitize_key($_GET['post_type']) : '';
+        if ('aicp_assistant' === $requested_type) {
+            $is_edit_screen = true;
+        }
     }
+
+    if (!$is_edit_screen) {
+        return;
+    }
+
+    wp_enqueue_media();
+    wp_enqueue_style('wp-color-picker');
+    wp_enqueue_style('aicp-admin-styles', AICP_PLUGIN_URL . 'assets/css/admin.css', [], AICP_VERSION);
+    wp_enqueue_style('aicp-chatbot-preview-styles', AICP_PLUGIN_URL . 'assets/css/chatbot.css', [], AICP_VERSION);
+    wp_register_script('aicp-templates', AICP_PLUGIN_URL . 'templates/templates.js', [], AICP_VERSION, true);
+    wp_enqueue_script('aicp-templates');
+    wp_enqueue_script('aicp-admin-script', AICP_PLUGIN_URL . 'assets/js/admin-scripts.js', ['jquery', 'wp-color-picker', 'aicp-templates'], AICP_VERSION, true);
+
+    $settings = [];
+    if ($post_id > 0) {
+        $settings = get_post_meta($post_id, '_aicp_assistant_settings', true);
+    }
+    if (!is_array($settings)) {
+        $settings = [];
+    }
+
+    $default_bot_avatar  = AICP_PLUGIN_URL . 'assets/bot-default-avatar.png';
+    $default_user_avatar = AICP_PLUGIN_URL . 'assets/user-default-avatar.png';
+    $default_open_icon   = 'data:image/svg+xml;base64,' . base64_encode('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white"><path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z"/></svg>');
+
+    $meta = [
+        'brand' => sanitize_text_field(get_option('aicp_brand', '')),
+        'domain' => sanitize_text_field(get_option('aicp_domain', '')),
+        'services' => array_map('sanitize_text_field', (array) get_option('aicp_services', [])),
+        'pricing_ranges' => array_map('sanitize_text_field', (array) get_option('aicp_pricing_ranges', [])),
+        'timezone' => sanitize_text_field(wp_timezone_string()),
+    ];
+
+    wp_localize_script('aicp-admin-script', 'aicp_admin_params', [
+        'ajax_url' => admin_url('admin-ajax.php'),
+        'assistant_id' => $post_id,
+        'delete_nonce' => wp_create_nonce('aicp_delete_log_nonce'),
+        'get_log_nonce' => wp_create_nonce('aicp_get_log_nonce'),
+        'capture_lead_nonce' => wp_create_nonce('aicp_capture_lead_nonce'),
+        'default_bot_avatar' => $default_bot_avatar,
+        'default_user_avatar' => $default_user_avatar,
+        'default_open_icon' => $default_open_icon,
+        'templates_url' => AICP_PLUGIN_URL . 'assistant_templates.json',
+        'initial_settings' => [
+            'bot_avatar_url' => $settings['bot_avatar_url'] ?? $default_bot_avatar,
+            'user_avatar_url' => $settings['user_avatar_url'] ?? $default_user_avatar,
+            'open_icon_url' => $settings['open_icon_url'] ?? $default_open_icon,
+            'position' => $settings['position'] ?? 'br',
+            'color_primary' => $settings['color_primary'] ?? '#0073aa',
+            'color_bot_bg' => $settings['color_bot_bg'] ?? '#ffffff',
+            'color_bot_text' => $settings['color_bot_text'] ?? '#333333',
+            'color_user_bg' => $settings['color_user_bg'] ?? '#dcf8c6',
+            'color_user_text' => $settings['color_user_text'] ?? '#000000',
+            'template_id' => $settings['template_id'] ?? '',
+            'persona' => $settings['persona'] ?? '',
+            'objective' => $settings['objective'] ?? '',
+            'length_tone' => $settings['length_tone'] ?? '',
+            'example' => $settings['example'] ?? '',
+            'quick_replies' => is_array($settings['quick_replies'] ?? null) ? $settings['quick_replies'] : [],
+        ],
+        'meta' => $meta,
+    ]);
 }
 add_action('admin_enqueue_scripts', 'aicp_admin_scripts');
 

--- a/aicp-advanced-training/aicp-advanced-training.php
+++ b/aicp-advanced-training/aicp-advanced-training.php
@@ -42,7 +42,19 @@ function aicp_pro_init() {
 function aicp_pro_enqueue_admin_scripts($hook) {
     global $post;
 
-    $is_assistant_edit_page = ($hook == 'post-new.php' || $hook == 'post.php') && isset($post) && $post->post_type === 'aicp_assistant';
+    $is_assistant_edit_page = false;
+    $post_id = 0;
+
+    if ($hook === 'post.php' && isset($post) && isset($post->post_type) && $post->post_type === 'aicp_assistant') {
+        $is_assistant_edit_page = true;
+        $post_id = (int) $post->ID;
+    } elseif ($hook === 'post-new.php') {
+        $requested_type = isset($_GET['post_type']) ? sanitize_key($_GET['post_type']) : '';
+        if ('aicp_assistant' === $requested_type) {
+            $is_assistant_edit_page = true;
+        }
+    }
+
     $is_settings_page = ($hook === 'aicp_assistant_page_aicp-settings');
 
     if ($is_assistant_edit_page || $is_settings_page) {
@@ -58,9 +70,10 @@ function aicp_pro_enqueue_admin_scripts($hook) {
         // Prepara y pasa variables de PHP a JavaScript de forma segura
         $params = [ 'ajax_url' => admin_url('admin-ajax.php') ];
         if ($is_assistant_edit_page) {
-            $params['assistant_id'] = $post->ID;
+            $params['assistant_id'] = $post_id;
             $params['nonce'] = wp_create_nonce('aicp_save_meta_box_data');
         } else {
+            $params['assistant_id'] = 0;
             $params['nonce'] = wp_create_nonce('aicp_global_settings_nonce');
         }
         wp_localize_script('aicp-admin-pro-js', 'aicp_pro_params', $params);

--- a/aicp-advanced-training/assets/js/admin-pro.js
+++ b/aicp-advanced-training/assets/js/admin-pro.js
@@ -5,9 +5,20 @@ jQuery(function($) {
 
     // --- MANEJADOR PARA EL BOTÓN DE SINCRONIZACIÓN (EN PÁGINA DE ASISTENTE) ---
     if ($('body').hasClass('post-type-aicp_assistant')) {
+        const assistantId = parseInt(aicp_pro_params.assistant_id || 0, 10) || 0;
+        if (!assistantId) {
+            $('#aicp-sync-button').prop('disabled', true);
+            $('#aicp-sync-status').text('Guarda el asistente antes de sincronizar.').css('color', 'red');
+        }
         $('#aicp-training-controls').on('click', '#aicp-sync-button', function() {
             const $button = $(this);
             const $status = $('#aicp-sync-status');
+            const currentAssistantId = parseInt(aicp_pro_params.assistant_id || 0, 10) || 0;
+
+            if (!currentAssistantId) {
+                $status.text('Guarda el asistente antes de sincronizar.').css('color', 'red');
+                return;
+            }
             const selectedPostIds = $('input[name="aicp_settings[training_post_ids][]"]:checked').map(function() { return $(this).val(); }).get();
             const selectedCptSlugs = $('input[name="aicp_settings[training_post_types][]"]:checked').map(function() { return $(this).val(); }).get();
 
@@ -27,7 +38,7 @@ jQuery(function($) {
                     nonce: aicp_pro_params.nonce,
                     post_ids: selectedPostIds,
                     cpt_slugs: selectedCptSlugs,
-                    assistant_id: aicp_pro_params.assistant_id
+                    assistant_id: currentAssistantId
                 },
                 success: function(response) {
                     if (response.success) {


### PR DESCRIPTION
## Summary
- ensure the main plugin enqueues admin scripts when creating new assistants and provide safe defaults for localized data
- update the advanced training addon to detect new assistant screens and pass a valid assistant id to JavaScript
- guard the sync control in the PRO script so it guides the user to save before synchronising content

## Testing
- php -l admin/assistant-meta-boxes.php
- php -l ../aicp-advanced-training/aicp-advanced-training.php

------
https://chatgpt.com/codex/tasks/task_e_68eaa751a25c8330aa597891f3b41d7f