### PR TITLE
Restore calendar booking link and auto-open widget controls

### DIFF
--- a/ai-chatbot-pro/admin/assistant-meta-boxes.php
+++ b/ai-chatbot-pro/admin/assistant-meta-boxes.php
@@ -262,6 +262,7 @@ function aicp_render_leads_tab($assistant_id, $v) {
     $auto_collect = !empty($v['lead_auto_collect']);
     $lead_email   = $v['lead_email'] ?? '';
     $webhook      = esc_url($v['webhook_url'] ?? '');
+    $calendar_url = esc_url($v['calendar_url'] ?? '');
     
     // Nuevo campo para los campos de lead dinámicos
     $lead_fields = isset($v['lead_fields']) && is_array($v['lead_fields']) ? $v['lead_fields'] : [];
@@ -271,6 +272,7 @@ function aicp_render_leads_tab($assistant_id, $v) {
     echo '<tr><th><label>' . __('Captura Automática', 'ai-chatbot-pro') . '</label></th><td><label><input type="checkbox" name="aicp_settings[lead_auto_collect]" value="1" ' . checked($auto_collect, true, false) . '> ' . __('Solicitar datos de contacto automáticamente', 'ai-chatbot-pro') . '</label></td></tr>';
     echo '<tr><th><label for="aicp_lead_email">' . __('Email de notificación', 'ai-chatbot-pro') . '</label></th><td><input type="email" id="aicp_lead_email" name="aicp_settings[lead_email]" value="' . esc_attr($lead_email) . '" class="regular-text" /><br /><span class="description">' . sprintf(__('Si se deja vacío, se usará %s.', 'ai-chatbot-pro'), esc_html(get_option('admin_email'))) . '</span></td></tr>';
     echo '<tr><th><label for="aicp_webhook_url">' . __('Webhook URL', 'ai-chatbot-pro') . '</label></th><td><input type="url" name="aicp_settings[webhook_url]" id="aicp_webhook_url" value="' . esc_attr($webhook) . '" class="regular-text" placeholder="https://example.com/webhook" /></td></tr>';
+    echo '<tr><th><label for="aicp_calendar_url">' . __('URL del Calendario para Reservar Cita', 'ai-chatbot-pro') . '</label></th><td><input type="url" name="aicp_settings[calendar_url]" id="aicp_calendar_url" value="' . esc_attr($calendar_url) . '" class="regular-text" placeholder="https://example.com/agenda" /><br /><span class="description">' . __('Si se configura, el asistente mostrará un botón para reservar una cita cuando detecte intención de agendar.', 'ai-chatbot-pro') . '</span></td></tr>';
     echo '</tbody></table>';
 
     // Sección para campos de lead dinámicos
@@ -443,6 +445,7 @@ function aicp_save_meta_box_data($post_id) {
     $current['lead_auto_collect'] = !empty($s['lead_auto_collect']) ? 1 : 0;
     $current['lead_email']        = isset($s['lead_email']) ? sanitize_email($s['lead_email']) : '';
     $current['webhook_url']       = isset($s['webhook_url']) ? esc_url_raw($s['webhook_url']) : '';
+    $current['calendar_url']      = isset($s['calendar_url']) ? esc_url_raw($s['calendar_url']) : '';
 
     // Guardar los nuevos campos de lead dinámicos
     $current['lead_fields'] = [];

--- a/ai-chatbot-pro/assets/js/chatbot.js
+++ b/ai-chatbot-pro/assets/js/chatbot.js
@@ -26,6 +26,9 @@ jQuery(function($) {
     let userMessageCount = 0;
     let leadButtonsShown = false;
     let inactivityTimer = null;
+    let autoOpenTimeout = null;
+    let autoCloseTimeout = null;
+    let hasUserInteracted = false;
 
     const farewellPatterns = [
         /ad[ií]os/i,
@@ -48,6 +51,7 @@ jQuery(function($) {
     const leadButtonThreshold = 3;
 
     function resetInactivityTimer() {
+        if (isChatEnded) return;
         clearTimeout(inactivityTimer);
         inactivityTimer = setTimeout(finalizeChat, 45000);
     }
@@ -169,16 +173,85 @@ function renderQuickReplies() {
         });
     }
 
-    function toggleChatWindow() {
-        isChatOpen = !isChatOpen;
-        $('#aicp-chat-window, #aicp-chat-toggle-button').toggleClass('active');
-        if (isChatOpen) $('#aicp-chat-input').focus();
+    function clearAutoOpenTimeout() {
+        if (autoOpenTimeout) {
+            clearTimeout(autoOpenTimeout);
+            autoOpenTimeout = null;
+        }
     }
-    
+
+    function clearAutoCloseTimeout() {
+        if (autoCloseTimeout) {
+            clearTimeout(autoCloseTimeout);
+            autoCloseTimeout = null;
+        }
+    }
+
+    function markUserInteraction() {
+        if (hasUserInteracted) return;
+        hasUserInteracted = true;
+        clearAutoOpenTimeout();
+        clearAutoCloseTimeout();
+    }
+
+    function openChatWindow(isAuto = false) {
+        if (isChatOpen) return;
+        isChatOpen = true;
+        $('#aicp-chat-window, #aicp-chat-toggle-button').addClass('active');
+        clearAutoOpenTimeout();
+        if (!isAuto) {
+            markUserInteraction();
+        }
+        $('#aicp-chat-input').focus();
+    }
+
+    function closeChatWindow(isAuto = false) {
+        if (!isChatOpen) return;
+        isChatOpen = false;
+        $('#aicp-chat-window, #aicp-chat-toggle-button').removeClass('active');
+        if (!isAuto) {
+            markUserInteraction();
+        }
+    }
+
+    function toggleChatWindow(event) {
+        if (event) event.preventDefault();
+        if (isChatOpen) {
+            closeChatWindow();
+        } else {
+            openChatWindow();
+        }
+    }
+
+    function scheduleAutoOpen() {
+        if (!params.auto_open || !params.auto_open.enabled) return;
+
+        const delay = Math.max(0, parseInt(params.auto_open.delay, 10) || 0);
+        const duration = Math.max(0, parseInt(params.auto_open.duration, 10) || 0);
+
+        clearAutoOpenTimeout();
+        clearAutoCloseTimeout();
+
+        autoOpenTimeout = setTimeout(() => {
+            if (hasUserInteracted || isChatOpen) return;
+            openChatWindow(true);
+
+            if (duration > 0) {
+                clearAutoCloseTimeout();
+                autoCloseTimeout = setTimeout(() => {
+                    if (!hasUserInteracted && isChatOpen) {
+                        closeChatWindow(true);
+                    }
+                }, duration * 1000);
+            }
+        }, delay * 1000);
+    }
+
     function addMessageToChat(role, text, isCalendarMessage = false) {
         resetInactivityTimer();
         const $chatBody = $('.aicp-chat-body');
-        let sanitizedText = $('<div/>').text(text).html().replace(/\n/g, '<br>');
+        const messageText = text == null ? '' : String(text);
+        let sanitizedText = $('<div/>').text(messageText).html().replace(/\n/g, '<br>');
         
         if (isCalendarMessage && params.calendar_url) {
             sanitizedText += `<br><br><a href="${params.calendar_url}" class="aicp-calendar-link" data-log-id="${logId}" data-assistant-id="${params.assistant_id}" data-calendar-nonce="${params.calendar_nonce}" target="_blank">📅 Reservar cita</a>`;
@@ -362,6 +435,7 @@ function renderQuickReplies() {
         const leadDetected = detectLeadData(message);
 
         conversationHistory.push({ role: 'user', content: message });
+        markUserInteraction();
         addMessageToChat('user', message);
         $('.aicp-quick-replies').slideUp();
 
@@ -420,7 +494,8 @@ function renderQuickReplies() {
                         });
                     }
                 } else {
-                    addMessageToChat('bot', `Error: ${response.data.message}`);
+                    const errorMessage = response && response.data && response.data.message ? response.data.message : 'No se pudo procesar la solicitud en este momento.';
+                    addMessageToChat('bot', `Error: ${errorMessage}`);
                 }
             },
             error: () => addMessageToChat('bot', 'Lo siento, ha ocurrido un error de conexión.'),
@@ -442,8 +517,10 @@ function renderQuickReplies() {
         }
     }
     
-    function handleQuickReplyClick() {
+    function handleQuickReplyClick(e) {
+        if (e) e.preventDefault();
         const message = $(this).text();
+        markUserInteraction();
         sendMessage(message);
     }
 
@@ -474,6 +551,7 @@ function renderQuickReplies() {
 
     function handleCalendarClick(e) {
         e.preventDefault();
+        markUserInteraction();
         const $link = $(this);
         const calendarLogId = $link.data('log-id');
         const assistantId = $link.data('assistant-id');
@@ -503,7 +581,9 @@ function renderQuickReplies() {
         $(document).on('click', '.aicp-quick-reply', handleQuickReplyClick);
         $(document).on('click', '.aicp-feedback-btn', handleFeedbackClick);
         $(document).on('click', '.aicp-calendar-link', handleCalendarClick);
-        
+        $(document).on('focus', '#aicp-chat-input', markUserInteraction);
+
         resetInactivityTimer();
+        scheduleAutoOpen();
     }
 });

--- a/ai-chatbot-pro/includes/class-frontend-loader.php
+++ b/ai-chatbot-pro/includes/class-frontend-loader.php
@@ -96,11 +96,12 @@ class AICP_Frontend_Loader {
             $quick_replies = array_map('trim', $s['quick_replies']);
         }
 
-
-        // Obtener configuración de detección de leads
-
-        $lead_auto_collect  = !empty($s['lead_auto_collect']) ? true : false;
-
+        // Obtener configuración adicional
+        $lead_auto_collect  = !empty($s['lead_auto_collect']);
+        $calendar_url       = !empty($s['calendar_url']) ? esc_url($s['calendar_url']) : '';
+        $auto_open_enabled  = !empty($s['auto_open_enabled']);
+        $auto_open_delay    = isset($s['auto_open_delay']) ? max(0, intval($s['auto_open_delay'])) : 0;
+        $auto_open_duration = isset($s['auto_open_duration']) ? max(0, intval($s['auto_open_duration'])) : 0;
 
         wp_localize_script('aicp-chatbot-script', 'aicp_chatbot_params', [
             'ajax_url' => admin_url('admin-ajax.php'),
@@ -118,8 +119,12 @@ class AICP_Frontend_Loader {
             'quick_replies' => $quick_replies,
 
             'lead_auto_collect'  => $lead_auto_collect,
-
-
+            'calendar_url'       => $calendar_url,
+            'auto_open'          => [
+                'enabled'  => $auto_open_enabled,
+                'delay'    => $auto_open_delay,
+                'duration' => $auto_open_duration,
+            ],
         ]);
     }
 

--- a/aicp-advanced-training/includes/class-pro-features.php
+++ b/aicp-advanced-training/includes/class-pro-features.php
@@ -17,6 +17,9 @@ class AICP_Pro_Features {
         $selected_posts = $settings['training_post_ids'] ?? [];
         $selected_cpts = $settings['training_post_types'] ?? [];
         $selected_files = isset($settings['training_file_ids']) && is_array($settings['training_file_ids']) ? array_map('intval', $settings['training_file_ids']) : [];
+        $auto_open_enabled = !empty($settings['auto_open_enabled']);
+        $auto_open_delay = isset($settings['auto_open_delay']) ? absint($settings['auto_open_delay']) : 5;
+        $auto_open_duration = isset($settings['auto_open_duration']) ? absint($settings['auto_open_duration']) : 0;
         
         // --- INICIO DE LA MODIFICACIÓN ---
         // Obtener las reglas de comportamiento guardadas
@@ -98,6 +101,35 @@ class AICP_Pro_Features {
             <span id="aicp-sync-status" style="font-weight: bold;"></span>
         </div>
 
+        <hr style="margin: 30px 0;">
+        <h4><?php _e('Comportamiento Avanzado del Widget', 'ai-chatbot-pro'); ?></h4>
+        <p class="description"><?php _e('Configura la apertura automática del chat para maximizar la captación de leads.', 'ai-chatbot-pro'); ?></p>
+        <table class="form-table">
+            <tr>
+                <th scope="row"><?php _e('Apertura Automática', 'ai-chatbot-pro'); ?></th>
+                <td>
+                    <label>
+                        <input type="checkbox" name="aicp_settings[auto_open_enabled]" value="1" <?php checked($auto_open_enabled); ?>>
+                        <?php _e('Abrir el chat automáticamente tras cargar la página.', 'ai-chatbot-pro'); ?>
+                    </label>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="aicp_auto_open_delay"><?php _e('Retraso antes de abrir (segundos)', 'ai-chatbot-pro'); ?></label></th>
+                <td>
+                    <input type="number" min="0" id="aicp_auto_open_delay" name="aicp_settings[auto_open_delay]" value="<?php echo esc_attr($auto_open_delay); ?>" class="small-text">
+                    <span class="description"><?php _e('Tiempo que el widget esperará antes de mostrarse automáticamente.', 'ai-chatbot-pro'); ?></span>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="aicp_auto_open_duration"><?php _e('Tiempo visible antes de cerrarse (segundos)', 'ai-chatbot-pro'); ?></label></th>
+                <td>
+                    <input type="number" min="0" id="aicp_auto_open_duration" name="aicp_settings[auto_open_duration]" value="<?php echo esc_attr($auto_open_duration); ?>" class="small-text">
+                    <span class="description"><?php _e('Usa 0 para mantener el chat abierto hasta que el usuario interactúe.', 'ai-chatbot-pro'); ?></span>
+                </td>
+            </tr>
+        </table>
+
         <div style="margin-top: 20px; padding: 15px; background-color: #f7f7f7; border-left: 4px solid #7e8993;">
             <strong><?php _e('Estado de la Sincronización:', 'ai-chatbot-pro'); ?></strong>
             <p style="margin: 5px 0;"><?php if ($last_sync_time) : ?>Última sincronización: <?php echo date_i18n(get_option('date_format') . ' H:i', $last_sync_time); ?> (<?php echo esc_html($last_sync_count); ?> posts/páginas procesados).<?php else: ?>Este asistente no se ha sincronizado nunca.<?php endif; ?></p>
@@ -143,6 +175,10 @@ class AICP_Pro_Features {
         if (isset($new_settings['behavior_rules'])) {
             $current_settings['behavior_rules'] = sanitize_textarea_field($new_settings['behavior_rules']);
         }
+
+        $current_settings['auto_open_enabled'] = !empty($new_settings['auto_open_enabled']) ? 1 : 0;
+        $current_settings['auto_open_delay'] = isset($new_settings['auto_open_delay']) ? max(0, intval($new_settings['auto_open_delay'])) : 0;
+        $current_settings['auto_open_duration'] = isset($new_settings['auto_open_duration']) ? max(0, intval($new_settings['auto_open_duration'])) : 0;
 
         update_post_meta($post_id, '_aicp_assistant_settings', $current_settings);
     }


### PR DESCRIPTION
## Summary
- add a configurable calendar booking URL to assistant lead settings and expose it to the chat widget
- implement configurable auto-open behaviour with timer management and improved error messaging in the frontend script
- surface PRO controls for auto-open timing and persist them in assistant settings

## Testing
- php -l ai-chatbot-pro/admin/assistant-meta-boxes.php
- php -l ai-chatbot-pro/includes/class-frontend-loader.php
- php -l aicp-advanced-training/includes/class-pro-features.php

------
https://chatgpt.com/codex/tasks/task_e_68eaabbb7a208330a5043a8f1d6d2301