### PR TITLE
Fix assistant sync fallback and auto-open welcome flow

### DIFF
--- a/ai-chatbot-pro/assets/js/chatbot.js
+++ b/ai-chatbot-pro/assets/js/chatbot.js
@@ -12,6 +12,7 @@ jQuery(function($) {
     let isChatOpen = false;
     let isThinking = false;
     let isChatEnded = false;
+    let sessionId = null;
     let leadData = {
         email: null,
         name: null,
@@ -29,6 +30,7 @@ jQuery(function($) {
     let autoOpenTimeout = null;
     let autoCloseTimeout = null;
     let hasUserInteracted = false;
+    let autoWelcomeShown = false;
 
     const farewellPatterns = [
         /ad[ií]os/i,
@@ -223,6 +225,16 @@ function renderQuickReplies() {
         }
     }
 
+    function maybeShowAutoWelcomeMessage() {
+        if (autoWelcomeShown) return;
+        const welcomeMessage = params.auto_open && params.auto_open.message ? params.auto_open.message.trim() : '';
+        if (!welcomeMessage) return;
+
+        addMessageToChat('bot', welcomeMessage);
+        conversationHistory.push({ role: 'assistant', content: welcomeMessage });
+        autoWelcomeShown = true;
+    }
+
     function scheduleAutoOpen() {
         if (!params.auto_open || !params.auto_open.enabled) return;
 
@@ -235,6 +247,7 @@ function renderQuickReplies() {
         autoOpenTimeout = setTimeout(() => {
             if (hasUserInteracted || isChatOpen) return;
             openChatWindow(true);
+            maybeShowAutoWelcomeMessage();
 
             if (duration > 0) {
                 clearAutoCloseTimeout();
@@ -462,21 +475,23 @@ function renderQuickReplies() {
         }
 
         $.ajax({
-            url: params.ajax_url, 
+            url: params.ajax_url,
             type: 'POST',
-            data: { 
-                action: 'aicp_chat_request', 
+            data: {
+                action: 'aicp_chat_request',
                 nonce: params.nonce,
                 assistant_id: params.assistant_id,
                 history: conversationHistory,
                 log_id: logId,
                 lead_data: leadData,
-                page_context: getPageContext()
+                page_context: getPageContext(),
+                session_id: sessionId
             },
             success: (response) => {
                 if (response.success) {
                     const botReply = response.data.reply;
                     logId = response.data.log_id;
+                    sessionId = response.data.session_id || sessionId;
                     const parts = splitLongMessage(botReply, 170);
                     parts.forEach(part => {
                         conversationHistory.push({ role: 'assistant', content: part });
@@ -585,5 +600,8 @@ function renderQuickReplies() {
 
         resetInactivityTimer();
         scheduleAutoOpen();
+        if (params.auto_open && params.auto_open.enabled && parseInt(params.auto_open.delay, 10) === 0) {
+            maybeShowAutoWelcomeMessage();
+        }
     }
 });

--- a/ai-chatbot-pro/includes/class-frontend-loader.php
+++ b/ai-chatbot-pro/includes/class-frontend-loader.php
@@ -102,6 +102,7 @@ class AICP_Frontend_Loader {
         $auto_open_enabled  = !empty($s['auto_open_enabled']);
         $auto_open_delay    = isset($s['auto_open_delay']) ? max(0, intval($s['auto_open_delay'])) : 0;
         $auto_open_duration = isset($s['auto_open_duration']) ? max(0, intval($s['auto_open_duration'])) : 0;
+        $auto_open_message  = isset($s['auto_open_message']) ? sanitize_textarea_field($s['auto_open_message']) : '';
 
         wp_localize_script('aicp-chatbot-script', 'aicp_chatbot_params', [
             'ajax_url' => admin_url('admin-ajax.php'),
@@ -124,6 +125,7 @@ class AICP_Frontend_Loader {
                 'enabled'  => $auto_open_enabled,
                 'delay'    => $auto_open_delay,
                 'duration' => $auto_open_duration,
+                'message'  => $auto_open_message,
             ],
         ]);
     }

--- a/aicp-advanced-training/aicp-advanced-training.php
+++ b/aicp-advanced-training/aicp-advanced-training.php
@@ -59,6 +59,9 @@ function aicp_pro_enqueue_admin_scripts($hook) {
 
     if ($is_assistant_edit_page || $is_settings_page) {
         $plugin_url = plugin_dir_url(__FILE__);
+        if ($is_assistant_edit_page && function_exists('wp_enqueue_media')) {
+            wp_enqueue_media();
+        }
         wp_enqueue_script(
             'aicp-admin-pro-js',
             $plugin_url . 'assets/js/admin-pro.js',

--- a/aicp-advanced-training/includes/class-openai-assistants-manager.php
+++ b/aicp-advanced-training/includes/class-openai-assistants-manager.php
@@ -227,42 +227,91 @@ class AICP_OpenAI_Assistants_Manager {
         wp_send_json_success(['message' => '¡Sincronización con OpenAI completada!', 'count' => $total_sources, 'files' => count($uploaded_file_ids)]);
     }
 
-    public static function handle_chat($assistant_id_wp, $user_message, $session_id) {
-        $openai_assistant_id = get_post_meta($assistant_id_wp, '_aicp_openai_assistant_id', true);
-        if (empty($openai_assistant_id)) return new WP_Error('config_error', 'Este asistente no está sincronizado.');
+    private static function sanitize_session_id($session_id) {
+        $session_id = is_string($session_id) ? preg_replace('/[^a-zA-Z0-9_-]/', '', $session_id) : '';
+        if (empty($session_id)) {
+            $session_id = 'aicp_' . wp_generate_uuid4();
+        }
+        return $session_id;
+    }
 
-        $thread_id = get_transient("aicp_thread_{$session_id}");
-        if (empty($thread_id)) {
-            $response = self::remote_request('threads', []);
-            $body = json_decode(wp_remote_retrieve_body($response), true);
-            $thread_id = $body['id'];
-            set_transient("aicp_thread_{$session_id}", $thread_id, DAY_IN_SECONDS);
+    private static function get_thread_transient_key($session_id) {
+        return 'aicp_thread_' . md5($session_id);
+    }
+
+    public static function handle_chat($assistant_id_wp, $user_message, $session_id = '') {
+        $openai_assistant_id = get_post_meta($assistant_id_wp, '_aicp_openai_assistant_id', true);
+        if (empty($openai_assistant_id)) {
+            return new WP_Error('config_error', 'Este asistente no está sincronizado.');
         }
 
-        self::remote_request("threads/{$thread_id}/messages", ['role' => 'user', 'content' => $user_message]);
-        
+        $session_id = self::sanitize_session_id($session_id);
+        $thread_key = self::get_thread_transient_key($session_id);
+
+        $thread_id = get_transient($thread_key);
+        if (empty($thread_id)) {
+            $response = self::remote_request('threads', []);
+            if (is_wp_error($response)) {
+                return $response;
+            }
+            $code = wp_remote_retrieve_response_code($response);
+            $body = json_decode(wp_remote_retrieve_body($response), true);
+            if ($code !== 200 || empty($body['id'])) {
+                $message = $body['error']['message'] ?? 'No se pudo crear el hilo en OpenAI.';
+                return new WP_Error('thread_error', $message);
+            }
+            $thread_id = $body['id'];
+            set_transient($thread_key, $thread_id, DAY_IN_SECONDS);
+        }
+
+        $message_response = self::remote_request("threads/{$thread_id}/messages", ['role' => 'user', 'content' => $user_message]);
+        if (is_wp_error($message_response)) {
+            return $message_response;
+        }
+
         $run_response = self::remote_request("threads/{$thread_id}/runs", ['assistant_id' => $openai_assistant_id]);
+        if (is_wp_error($run_response)) {
+            return $run_response;
+        }
         $run_body = json_decode(wp_remote_retrieve_body($run_response), true);
-        if(empty($run_body['id'])) return new WP_Error('run_error', 'No se pudo iniciar la ejecución del asistente en OpenAI.');
+        if (empty($run_body['id'])) {
+            $error_message = $run_body['error']['message'] ?? 'No se pudo iniciar la ejecución del asistente en OpenAI.';
+            return new WP_Error('run_error', $error_message);
+        }
         $run_id = $run_body['id'];
 
         $start_time = time();
+        $run_status_body = null;
         while (time() - $start_time < 30) {
             $run_status_response = self::remote_request("threads/{$thread_id}/runs/{$run_id}", [], 'GET');
+            if (is_wp_error($run_status_response)) {
+                return $run_status_response;
+            }
             $run_status_body = json_decode(wp_remote_retrieve_body($run_status_response), true);
-            if (in_array($run_status_body['status'], ['completed', 'failed', 'cancelled'])) break;
+            if (isset($run_status_body['status']) && in_array($run_status_body['status'], ['completed', 'failed', 'cancelled'], true)) {
+                break;
+            }
             sleep(1);
         }
 
-        if ($run_status_body['status'] !== 'completed') return new WP_Error('run_error', 'La IA tardó demasiado en responder o encontró un error. Estado: ' . $run_status_body['status']);
-        
+        if (!isset($run_status_body['status']) || $run_status_body['status'] !== 'completed') {
+            $status = $run_status_body['status'] ?? 'unknown';
+            return new WP_Error('run_error', 'La IA tardó demasiado en responder o encontró un error. Estado: ' . $status);
+        }
+
         $messages_response = self::remote_request("threads/{$thread_id}/messages?limit=1", [], 'GET');
+        if (is_wp_error($messages_response)) {
+            return $messages_response;
+        }
         $messages_body = json_decode(wp_remote_retrieve_body($messages_response), true);
 
         if (!empty($messages_body['data'][0]['content'][0]['text']['value'])) {
-             $raw_response = $messages_body['data'][0]['content'][0]['text']['value'];
-             $clean_response = preg_replace('/【.*?】/u', '', $raw_response);
-             return trim($clean_response);
+            $raw_response = $messages_body['data'][0]['content'][0]['text']['value'];
+            $clean_response = preg_replace('/【.*?】/u', '', $raw_response);
+            return [
+                'reply' => trim($clean_response),
+                'session_id' => $session_id,
+            ];
         }
 
         return new WP_Error('no_response', 'La IA no proporcionó una respuesta válida.');

--- a/aicp-advanced-training/includes/class-pro-ajax-handler.php
+++ b/aicp-advanced-training/includes/class-pro-ajax-handler.php
@@ -3,6 +3,52 @@ if (!defined('ABSPATH')) exit;
 
 class AICP_Pro_Ajax_Handler {
 
+    private static function save_conversation($log_id, $assistant_id, $session_id, $conversation, $lead_data = []) {
+        global $wpdb;
+        $table_name = $wpdb->prefix . 'aicp_chat_logs';
+
+        $first_user_message = '';
+        if ($log_id === 0) {
+            foreach ($conversation as $message) {
+                if (isset($message['role'], $message['content']) && $message['role'] === 'user') {
+                    $first_user_message = $message['content'];
+                    break;
+                }
+            }
+        }
+
+        $data = [
+            'assistant_id'     => $assistant_id,
+            'session_id'       => $session_id,
+            'timestamp'        => current_time('mysql'),
+            'conversation_log' => wp_json_encode($conversation, JSON_UNESCAPED_UNICODE),
+        ];
+        $format = ['%d', '%s', '%s', '%s'];
+
+        if ($first_user_message) {
+            $data['first_user_message'] = $first_user_message;
+            $format[] = '%s';
+        }
+
+        if (!empty($lead_data)) {
+            $data['has_lead'] = 1;
+            $data['lead_data'] = wp_json_encode($lead_data, JSON_UNESCAPED_UNICODE);
+            $format[] = '%d';
+            $format[] = '%s';
+        }
+
+        if ($log_id > 0) {
+            $wpdb->update($table_name, $data, ['id' => $log_id], $format, ['%d']);
+        } else {
+            $wpdb->insert($table_name, $data, $format);
+            $log_id = $wpdb->insert_id;
+        }
+
+        do_action('aicp_conversation_saved', $log_id, $assistant_id, $conversation);
+
+        return $log_id;
+    }
+
     public static function init() {
         add_action('wp_ajax_aicp_check_api_keys', [__CLASS__, 'handle_check_api_keys']);
         add_action('wp_ajax_aicp_start_sync', [__CLASS__, 'handle_start_sync']);
@@ -32,22 +78,103 @@ class AICP_Pro_Ajax_Handler {
 
     public static function handle_chat_request() {
         check_ajax_referer('aicp_chat_nonce', 'nonce');
+
         $assistant_id = isset($_POST['assistant_id']) ? absint($_POST['assistant_id']) : 0;
         $history = isset($_POST['history']) && is_array($_POST['history']) ? wp_unslash($_POST['history']) : [];
-        
+        $log_id = isset($_POST['log_id']) ? absint($_POST['log_id']) : 0;
+        $page_context = isset($_POST['page_context']) ? sanitize_textarea_field(wp_unslash($_POST['page_context'])) : '';
+        $incoming_session_id = isset($_POST['session_id']) ? sanitize_text_field(wp_unslash($_POST['session_id'])) : '';
+
         if (empty($assistant_id) || empty($history)) {
-            wp_send_json_error(['message' => 'Datos inválidos.']);
+            wp_send_json_error(['message' => __('Datos inválidos.', 'ai-chatbot-pro')]);
         }
 
-        $user_message = end($history)['content'];
-        $session_id = isset($_POST['session_id']) ? sanitize_text_field($_POST['session_id']) : 'sess_' . uniqid();
-
-        $response = AICP_OpenAI_Assistants_Manager::handle_chat($assistant_id, $user_message, $session_id);
-
-        if (is_wp_error($response)) {
-            wp_send_json_error(['message' => $response->get_error_message()]);
+        $global_settings = get_option('aicp_settings');
+        $api_key = $global_settings['api_key'] ?? '';
+        if (empty($api_key)) {
+            wp_send_json_error(['message' => __('La API Key de OpenAI no está configurada.', 'ai-chatbot-pro')]);
         }
-        
-        wp_send_json_success(['reply' => $response, 'session_id' => $session_id]);
+
+        $assistant_settings = get_post_meta($assistant_id, '_aicp_assistant_settings', true);
+        if (!is_array($assistant_settings)) {
+            $assistant_settings = [];
+        }
+
+        $system_prompt = AICP_Prompt_Builder::build($assistant_settings, $page_context);
+
+        $short_term_history = array_slice($history, -10);
+        $conversation_payload = [['role' => 'system', 'content' => $system_prompt]];
+        foreach ($short_term_history as $item) {
+            if (isset($item['role'], $item['content'])) {
+                $conversation_payload[] = [
+                    'role' => sanitize_key($item['role']),
+                    'content' => sanitize_textarea_field($item['content']),
+                ];
+            }
+        }
+
+        $user_message = end($short_term_history)['content'] ?? '';
+        if ($user_message === '') {
+            wp_send_json_error(['message' => __('Datos inválidos.', 'ai-chatbot-pro')]);
+        }
+
+        $session_id = $incoming_session_id;
+        $assistant_response = AICP_OpenAI_Assistants_Manager::handle_chat($assistant_id, $user_message, $session_id);
+        $reply = '';
+        if (is_wp_error($assistant_response)) {
+            if ($assistant_response->get_error_code() === 'config_error') {
+                $session_id = $session_id ?: 'aicp_' . wp_generate_uuid4();
+                $api_url = 'https://api.openai.com/v1/chat/completions';
+                $model = $assistant_settings['model'] ?? array_key_first(AICP_AVAILABLE_MODELS);
+                if (!isset(AICP_AVAILABLE_MODELS[$model])) {
+                    $model = array_key_first(AICP_AVAILABLE_MODELS);
+                }
+                $api_args = [
+                    'method'  => 'POST',
+                    'headers' => [
+                        'Content-Type'  => 'application/json',
+                        'Authorization' => 'Bearer ' . $api_key,
+                    ],
+                    'body'    => wp_json_encode([
+                        'model'    => $model,
+                        'messages' => $conversation_payload,
+                    ]),
+                    'timeout' => 60,
+                ];
+
+                $api_response = wp_remote_post($api_url, $api_args);
+                if (is_wp_error($api_response)) {
+                    wp_send_json_error(['message' => $api_response->get_error_message()]);
+                }
+
+                $body = json_decode(wp_remote_retrieve_body($api_response), true);
+                if (isset($body['choices'][0]['message']['content'])) {
+                    $reply = trim($body['choices'][0]['message']['content']);
+                } else {
+                    $error_message = $body['error']['message'] ?? __('Respuesta inesperada.', 'ai-chatbot-pro');
+                    wp_send_json_error(['message' => $error_message]);
+                }
+            } else {
+                wp_send_json_error(['message' => $assistant_response->get_error_message()]);
+            }
+        } else {
+            $reply = $assistant_response['reply'];
+            $session_id = $assistant_response['session_id'];
+        }
+
+        $full_history = $history;
+        $full_history[] = ['role' => 'assistant', 'content' => $reply];
+
+        $lead_info = AICP_Lead_Manager::detect_contact_data($full_history);
+
+        $new_log_id = self::save_conversation($log_id, $assistant_id, $session_id, $full_history, $lead_info['data']);
+
+        wp_send_json_success([
+            'reply'          => $reply,
+            'log_id'         => $new_log_id,
+            'lead_status'    => $lead_info['is_complete'] ? 'complete' : ($lead_info['has_lead'] ? 'partial' : 'none'),
+            'missing_fields' => $lead_info['missing_fields'],
+            'session_id'     => $session_id,
+        ]);
     }
 }

--- a/aicp-advanced-training/includes/class-pro-features.php
+++ b/aicp-advanced-training/includes/class-pro-features.php
@@ -20,6 +20,7 @@ class AICP_Pro_Features {
         $auto_open_enabled = !empty($settings['auto_open_enabled']);
         $auto_open_delay = isset($settings['auto_open_delay']) ? absint($settings['auto_open_delay']) : 5;
         $auto_open_duration = isset($settings['auto_open_duration']) ? absint($settings['auto_open_duration']) : 0;
+        $auto_open_message = isset($settings['auto_open_message']) ? $settings['auto_open_message'] : '';
         
         // --- INICIO DE LA MODIFICACIÓN ---
         // Obtener las reglas de comportamiento guardadas
@@ -128,6 +129,13 @@ class AICP_Pro_Features {
                     <span class="description"><?php _e('Usa 0 para mantener el chat abierto hasta que el usuario interactúe.', 'ai-chatbot-pro'); ?></span>
                 </td>
             </tr>
+            <tr>
+                <th scope="row"><label for="aicp_auto_open_message"><?php _e('Mensaje de bienvenida automático', 'ai-chatbot-pro'); ?></label></th>
+                <td>
+                    <textarea id="aicp_auto_open_message" name="aicp_settings[auto_open_message]" rows="3" class="large-text"><?php echo esc_textarea($auto_open_message); ?></textarea>
+                    <span class="description"><?php _e('Si se abre solo, el asistente mostrará este mensaje de bienvenida.', 'ai-chatbot-pro'); ?></span>
+                </td>
+            </tr>
         </table>
 
         <div style="margin-top: 20px; padding: 15px; background-color: #f7f7f7; border-left: 4px solid #7e8993;">
@@ -179,6 +187,7 @@ class AICP_Pro_Features {
         $current_settings['auto_open_enabled'] = !empty($new_settings['auto_open_enabled']) ? 1 : 0;
         $current_settings['auto_open_delay'] = isset($new_settings['auto_open_delay']) ? max(0, intval($new_settings['auto_open_delay'])) : 0;
         $current_settings['auto_open_duration'] = isset($new_settings['auto_open_duration']) ? max(0, intval($new_settings['auto_open_duration'])) : 0;
+        $current_settings['auto_open_message'] = isset($new_settings['auto_open_message']) ? sanitize_textarea_field($new_settings['auto_open_message']) : '';
 
         update_post_meta($post_id, '_aicp_assistant_settings', $current_settings);
     }


### PR DESCRIPTION
## Summary
- add session-aware chat handling on the frontend, including optional auto-open welcome messages and assistant session tracking
- ensure the auto-open welcome message setting is stored and exposed in the frontend script
- fall back to the standard completion flow when the assistant has not been synced while keeping lead logging intact, and enqueue media assets for file sync uploads

## Testing
- php -l aicp-advanced-training/includes/class-pro-ajax-handler.php
- php -l aicp-advanced-training/includes/class-openai-assistants-manager.php
- php -l aicp-advanced-training/includes/class-pro-features.php
- php -l ai-chatbot-pro/includes/class-frontend-loader.php
- php -l aicp-advanced-training/aicp-advanced-training.php

------
https://chatgpt.com/codex/tasks/task_e_68eaaf51267c833092ca9d22fcb4caa6