### PR TITLE
Lock assistant instructions when forwarding to webhook

### DIFF
--- a/ai-chatbot-pro/admin/assistant-meta-boxes.php
+++ b/ai-chatbot-pro/admin/assistant-meta-boxes.php
@@ -123,8 +123,10 @@ function aicp_admin_scripts($hook) {
             'length_tone' => $settings['length_tone'] ?? '',
             'example' => $settings['example'] ?? '',
             'quick_replies' => is_array($settings['quick_replies'] ?? null) ? $settings['quick_replies'] : [],
+            'forward_to_webhook' => !empty($settings['forward_to_webhook']),
         ],
         'meta' => $meta,
+        'webhook_warning' => __('Si activas el reenvío al webhook externo, el asistente ignorará las instrucciones internas y no podrás editarlas hasta desactivar la integración. ¿Deseas continuar?', 'ai-chatbot-pro'),
     ]);
 }
 add_action('admin_enqueue_scripts', 'aicp_admin_scripts');
@@ -177,8 +179,13 @@ function aicp_render_instructions_tab($v) {
         require_once AICP_PLUGIN_DIR . 'includes/class-prompt-builder.php';
     }
     $prompt = $v['custom_prompt'] ?? ($v['compiled_prompt'] ?? AICP_Prompt_Builder::build($v));
+    $is_forwarding_enabled = !empty($v['forward_to_webhook']);
     ?>
-    <table class="form-table">
+    <div class="notice notice-warning inline aicp-instructions-lock-notice"<?php echo $is_forwarding_enabled ? '' : ' style="display:none;"'; ?>>
+        <p><?php _e('Las instrucciones están desactivadas porque el asistente reenvía los mensajes a un webhook externo. Desactiva la integración para volver a editarlas.', 'ai-chatbot-pro'); ?></p>
+    </div>
+    <div class="aicp-instructions-fields<?php echo $is_forwarding_enabled ? ' aicp-instructions-locked' : ''; ?>">
+        <table class="form-table">
 
         <tr>
             <th><label for="aicp_model"><?php _e('Modelo de IA', 'ai-chatbot-pro'); ?></label></th>
@@ -215,7 +222,8 @@ function aicp_render_instructions_tab($v) {
                 <p><label><input type="checkbox" name="aicp_settings[use_custom_prompt]" id="aicp_edit_prompt_toggle" <?php checked(!empty($v['custom_prompt'])); ?>> <?php _e('Editar manualmente', 'ai-chatbot-pro'); ?></label></p>
             </td>
         </tr>
-    </table>
+        </table>
+    </div>
     <?php
 }
 

--- a/ai-chatbot-pro/assets/css/admin.css
+++ b/ai-chatbot-pro/assets/css/admin.css
@@ -97,6 +97,21 @@
 .aicp-modal-chat-transcript .message p { margin: 0; padding: 8px 12px; background: #f1f1f1; border-radius: 8px; white-space: pre-wrap; word-wrap: break-word; }
 #aicp-log-modal-footer { padding: 15px 30px; border-top: 1px solid #ddd; background: #f1f1f1; text-align: right; }
 
+/* Bloqueo de instrucciones cuando se usa el webhook */
+.aicp-instructions-lock-notice { margin: 0 0 15px; }
+.aicp-instructions-fields { position: relative; }
+.aicp-instructions-fields.aicp-instructions-locked::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(255, 255, 255, 0.65);
+    border-radius: 4px;
+    pointer-events: auto;
+    cursor: not-allowed;
+    z-index: 2;
+}
+.aicp-instructions-fields.aicp-instructions-locked table { filter: grayscale(0.6); }
+
 /* Página de analíticas */
 #aicp-analytics-page .aicp-stats-boxes { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 20px; margin-top: 20px; }
 #aicp-analytics-page .aicp-stat-box { background: #fff; padding: 20px; border: 1px solid #e5e5e5; box-shadow: 0 1px 1px rgba(0,0,0,.04); }

--- a/ai-chatbot-pro/assets/js/admin-scripts.js
+++ b/ai-chatbot-pro/assets/js/admin-scripts.js
@@ -195,6 +195,113 @@ jQuery(function($) {
         refresh();
     }
 
+    function handleWebhookToggle() {
+        const $toggle = $('#aicp_forward_to_webhook');
+        if (!$toggle.length) return;
+
+        const $fieldsContainer = $('.aicp-instructions-fields');
+        const $notice = $('.aicp-instructions-lock-notice');
+        const warningMessage = aicp_admin_params.webhook_warning || '';
+
+        const $lockableElements = $fieldsContainer.find('input:not([type="hidden"]), textarea, select, button').not('.aicp-lock-hidden');
+
+        function createHiddenMirror($el) {
+            const name = $el.attr('name');
+            if (!name) return null;
+            let $hidden = $el.data('aicpLockHidden');
+            if (!$hidden || !$hidden.length) {
+                $hidden = $('<input type="hidden" class="aicp-lock-hidden" />').attr('name', name);
+                $el.after($hidden);
+                $el.data('aicpLockHidden', $hidden);
+            }
+            if ($el.is(':checkbox')) {
+                $hidden.val($el.is(':checked') ? ($el.val() || 'on') : '');
+            } else {
+                $hidden.val($el.val());
+            }
+            return $hidden;
+        }
+
+        function removeHiddenMirror($el) {
+            const $hidden = $el.data('aicpLockHidden');
+            if ($hidden && $hidden.length) {
+                $hidden.remove();
+                $el.removeData('aicpLockHidden');
+            }
+        }
+
+        function lockElement($el) {
+            if ($el.is('textarea') || ($el.is('input') && !['checkbox', 'radio', 'button', 'submit'].includes($el.attr('type')))) {
+                if (typeof $el.data('aicpOriginalReadonly') === 'undefined') {
+                    $el.data('aicpOriginalReadonly', $el.prop('readonly'));
+                }
+                $el.prop('readonly', true);
+            }
+
+            if ($el.is('select') || $el.is(':checkbox') || $el.is(':radio')) {
+                if (typeof $el.data('aicpOriginalDisabled') === 'undefined') {
+                    $el.data('aicpOriginalDisabled', $el.prop('disabled'));
+                }
+                $el.prop('disabled', true);
+                createHiddenMirror($el);
+            }
+        }
+
+        function unlockElement($el) {
+            if ($el.is('textarea') || ($el.is('input') && !['checkbox', 'radio', 'button', 'submit'].includes($el.attr('type')))) {
+                if (typeof $el.data('aicpOriginalReadonly') !== 'undefined') {
+                    $el.prop('readonly', $el.data('aicpOriginalReadonly'));
+                }
+            }
+
+            if ($el.is('select') || $el.is(':checkbox') || $el.is(':radio')) {
+                if (typeof $el.data('aicpOriginalDisabled') !== 'undefined') {
+                    $el.prop('disabled', $el.data('aicpOriginalDisabled'));
+                } else {
+                    $el.prop('disabled', false);
+                }
+                removeHiddenMirror($el);
+            }
+        }
+
+        function setLockedState(locked, showWarning = false) {
+            if (locked && showWarning && warningMessage) {
+                const confirmed = window.confirm(warningMessage);
+                if (!confirmed) {
+                    $toggle.prop('checked', false);
+                    locked = false;
+                }
+            }
+
+            if (locked) {
+                $fieldsContainer.addClass('aicp-instructions-locked');
+                $notice.show();
+            } else {
+                $fieldsContainer.removeClass('aicp-instructions-locked');
+                $notice.hide();
+            }
+
+            $lockableElements.each(function() {
+                const $el = $(this);
+                if ($el.hasClass('aicp-lock-hidden')) return;
+                if (locked) {
+                    lockElement($el);
+                } else {
+                    unlockElement($el);
+                }
+            });
+        }
+
+        $toggle.on('change', function() {
+            setLockedState($toggle.is(':checked'), true);
+        });
+
+        const initialLocked = $toggle.is(':checked') || !!(aicp_admin_params.initial_settings && aicp_admin_params.initial_settings.forward_to_webhook);
+        if (initialLocked) {
+            setLockedState(true);
+        }
+    }
+
 
     function handleLivePreview(element, value) {
         const $el = $(element);
@@ -351,6 +458,7 @@ jQuery(function($) {
         handleDeleteLogFromList();
         initTemplateSelector();
         handleCustomPromptToggle();
+        handleWebhookToggle();
 
     }
 });

--- a/ai-chatbot-pro/includes/class-ajax-handler.php
+++ b/ai-chatbot-pro/includes/class-ajax-handler.php
@@ -200,17 +200,23 @@ class AICP_Ajax_Handler {
             $lead_payload = self::sanitize_lead_payload(wp_unslash($_POST['lead_data']));
         }
 
-        $system_prompt = AICP_Prompt_Builder::build($s, $page_context);
+        $use_webhook = !empty($s['forward_to_webhook']) && !empty($s['forward_webhook_url']);
+
+        $system_prompt = '';
+        if (!$use_webhook) {
+            $system_prompt = AICP_Prompt_Builder::build($s, $page_context);
+        }
 
         $short_term_memory = array_slice($history, -10);
-        $conversation = [['role' => 'system', 'content' => $system_prompt]];
+        $conversation = [];
+        if (!$use_webhook) {
+            $conversation[] = ['role' => 'system', 'content' => $system_prompt];
+        }
         foreach ($short_term_memory as $item) {
             if (isset($item['role'], $item['content'])) {
                 $conversation[] = ['role' => sanitize_key($item['role']), 'content' => sanitize_textarea_field($item['content'])];
             }
         }
-
-        $use_webhook = !empty($s['forward_to_webhook']) && !empty($s['forward_webhook_url']);
 
         $reply = '';
         $metadata = [];


### PR DESCRIPTION
## Summary
- disable the instructions tab UI when webhook forwarding is active and display a warning notice for administrators
- add styling and admin JavaScript to block editing, mirror values for disabled controls, and prompt for confirmation when enabling the n8n webhook
- skip building/sending the internal system prompt when the webhook handles replies

## Testing
- php -l ai-chatbot-pro/admin/assistant-meta-boxes.php
- php -l ai-chatbot-pro/includes/class-ajax-handler.php

------
https://chatgpt.com/codex/tasks/task_e_68f2309b6e4c833099085b8cc82c0f5d