### PR TITLE
Refuerza la captura de leads con campos configurables

### DIFF
--- a/ai-chatbot-pro/admin/assistant-meta-boxes.php
+++ b/ai-chatbot-pro/admin/assistant-meta-boxes.php
@@ -107,6 +107,7 @@ function aicp_admin_scripts($hook) {
         'default_user_avatar' => $default_user_avatar,
         'default_open_icon' => $default_open_icon,
         'templates_url' => AICP_PLUGIN_URL . 'assistant_templates.json',
+        'lead_fields' => AICP_Lead_Manager::get_lead_field_config($post_id, $settings),
         'initial_settings' => [
             'bot_avatar_url' => $settings['bot_avatar_url'] ?? $default_bot_avatar,
             'user_avatar_url' => $settings['user_avatar_url'] ?? $default_user_avatar,
@@ -297,11 +298,19 @@ function aicp_render_leads_tab($assistant_id, $v) {
     $lead_email   = $v['lead_email'] ?? '';
     $webhook      = esc_url($v['webhook_url'] ?? '');
     $calendar_url = esc_url($v['calendar_url'] ?? '');
+    $integration_active = !empty($v['forward_to_webhook']) && !empty($v['forward_webhook_url']);
     
     // Nuevo campo para los campos de lead dinámicos
     $lead_fields = isset($v['lead_fields']) && is_array($v['lead_fields']) ? $v['lead_fields'] : [];
 
     echo '<h4>' . __('Ajustes de Captura de Leads', 'ai-chatbot-pro') . '</h4>';
+
+    if ($integration_active) {
+        echo '<div class="notice notice-warning inline"><p>' . __('La integración con n8n está activa. Desactívala para configurar la captura de leads desde este apartado.', 'ai-chatbot-pro') . '</p></div>';
+    }
+
+    $fieldset_attr = $integration_active ? ' disabled="disabled"' : '';
+    echo '<fieldset class="aicp-lead-settings"' . $fieldset_attr . '>';
     echo '<table class="form-table"><tbody>';
     echo '<tr><th><label>' . __('Captura Automática', 'ai-chatbot-pro') . '</label></th><td><label><input type="checkbox" name="aicp_settings[lead_auto_collect]" value="1" ' . checked($auto_collect, true, false) . '> ' . __('Solicitar datos de contacto automáticamente', 'ai-chatbot-pro') . '</label></td></tr>';
     echo '<tr><th><label for="aicp_lead_email">' . __('Email de notificación', 'ai-chatbot-pro') . '</label></th><td><input type="email" id="aicp_lead_email" name="aicp_settings[lead_email]" value="' . esc_attr($lead_email) . '" class="regular-text" /><br /><span class="description">' . sprintf(__('Si se deja vacío, se usará %s.', 'ai-chatbot-pro'), esc_html(get_option('admin_email'))) . '</span></td></tr>';
@@ -326,7 +335,9 @@ function aicp_render_leads_tab($assistant_id, $v) {
     }
     
     echo '</tbody></table>';
-    echo '<button type="button" class="button aicp-add-lead-field">' . __('Añadir Campo', 'ai-chatbot-pro') . '</button>';
+    $add_button_attr = $integration_active ? ' disabled="disabled" aria-disabled="true"' : '';
+    echo '<button type="button" class="button aicp-add-lead-field"' . $add_button_attr . '>' . __('Añadir Campo', 'ai-chatbot-pro') . '</button>';
+    echo '</fieldset>';
 
     // Historial de Conversaciones
     $table_name = $wpdb->prefix . 'aicp_chat_logs';

--- a/ai-chatbot-pro/assets/js/admin-scripts.js
+++ b/ai-chatbot-pro/assets/js/admin-scripts.js
@@ -5,6 +5,9 @@ jQuery(function($) {
 
     if (typeof aicp_admin_params === 'undefined') return;
 
+    const leadFieldDefinitions = aicp_admin_params.lead_fields || {};
+    const escapeHtml = (text) => $('<div/>').text(text == null ? '' : String(text)).html();
+
     // Inicializar color pickers
     $('.aicp-color-picker').wpColorPicker({
         change: function(event, ui) {
@@ -80,10 +83,26 @@ jQuery(function($) {
 
         function populateModal(data, logId) {
             let leadHtml = '';
-            if (data.has_lead && data.lead_data) {
-                leadHtml = '<div class="aicp-modal-lead-data"><h3>Lead Capturado</h3>';
-                for (const [key, value] of Object.entries(data.lead_data)) { leadHtml += `<strong>${key.charAt(0).toUpperCase() + key.slice(1)}:</strong> ${value}<br>`; }
-                leadHtml += '</div>';
+            if (data.has_lead && data.lead_data && typeof data.lead_data === 'object' && !Array.isArray(data.lead_data)) {
+                const rows = [];
+                Object.entries(data.lead_data).forEach(([key, value]) => {
+                    if (key === 'is_complete') {
+                        return;
+                    }
+                    const definition = leadFieldDefinitions[key];
+                    const label = definition && definition.label ? definition.label : key.charAt(0).toUpperCase() + key.slice(1);
+                    let displayValue = value;
+                    if (Array.isArray(displayValue)) {
+                        displayValue = displayValue.join(', ');
+                    } else if (typeof displayValue === 'object' && displayValue !== null) {
+                        displayValue = JSON.stringify(displayValue);
+                    }
+                    rows.push(`<strong>${escapeHtml(label)}:</strong> ${escapeHtml(displayValue)}<br>`);
+                });
+
+                if (rows.length) {
+                    leadHtml = '<div class="aicp-modal-lead-data"><h3>Lead Capturado</h3>' + rows.join('') + '</div>';
+                }
             }
             let chatHtml = '<h3>Transcripción del Chat</h3><div class="aicp-modal-chat-transcript">';
             if (Array.isArray(data.conversation)) {
@@ -156,6 +175,9 @@ jQuery(function($) {
     function handleLeadQuestions() {
         $(document).on('click', '.aicp-add-lead-field', function(e) {
             e.preventDefault();
+            if ($(this).prop('disabled') || $(this).closest('fieldset').is(':disabled')) {
+                return;
+            }
             const $tableBody = $('.aicp-lead-fields-table tbody');
             const fieldId = 'field_' + Date.now();
             const newRow = `
@@ -177,6 +199,9 @@ jQuery(function($) {
 
         $(document).on('click', '.aicp-remove-lead-field', function(e) {
             e.preventDefault();
+            if ($(this).closest('fieldset').is(':disabled')) {
+                return;
+            }
             $(this).closest('tr').remove();
         });
     }

--- a/ai-chatbot-pro/assets/js/chatbot.js
+++ b/ai-chatbot-pro/assets/js/chatbot.js
@@ -13,13 +13,28 @@ jQuery(function($) {
     let isThinking = false;
     let isChatEnded = false;
     let sessionId = null;
-    let leadData = {
-        email: null,
-        name: null,
-        phone: null,
-        website: null,
-        isComplete: false
+
+    const defaultLeadDefinitions = params.lead_fields && Object.keys(params.lead_fields).length ? params.lead_fields : {
+        email: { label: 'email', required: true, type: 'email' },
+        name: { label: 'nombre', required: false, type: 'text' },
+        phone: { label: 'teléfono', required: false, type: 'phone' },
+        website: { label: 'sitio web', required: false, type: 'url' }
     };
+
+    const leadFieldDefinitions = defaultLeadDefinitions;
+    const leadFieldNames = Object.keys(leadFieldDefinitions);
+    const fieldNamesByType = {};
+    leadFieldNames.forEach((name) => {
+        let type = leadFieldDefinitions[name].type || 'text';
+        if (type === 'website') { type = 'url'; }
+        if (!fieldNamesByType[type]) { fieldNamesByType[type] = []; }
+        fieldNamesByType[type].push(name);
+    });
+    const requiredFieldNames = leadFieldNames.filter((name) => !!leadFieldDefinitions[name].required);
+
+    let leadData = { isComplete: false };
+    leadFieldNames.forEach((name) => { leadData[name] = null; });
+    leadData.source = 'chatbot_detection';
 
     let isCollectingLeadData = false;
     let currentLeadField = null;
@@ -44,11 +59,21 @@ jQuery(function($) {
 
 
     // --- Patrones de detección de leads ---
-    const leadPatterns = {
-        email: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g,
-        phone: /(?:\+?34[\s-]?)(?:6|7|8|9)[\s-]?\d{2}[\s-]?\d{2}[\s-]?\d{2}[\s-]?\d{2}|(?:\+?34[\s-]?)(?:91|93|94|95|96|97|98)[\s-]?\d{3}[\s-]?\d{3}/g,
-        website: /(?:https?:\/\/)?(?:www\.)?[a-zA-Z0-9-]+\.[a-zA-Z]{2,}(?:\/[^\s]*)?/g
-    };
+    const leadPatterns = {};
+    if ((fieldNamesByType.email || []).length) {
+        leadPatterns.email = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g;
+    }
+    if ((fieldNamesByType.phone || []).length) {
+        leadPatterns.phone = /(?:\+?34[\s-]?)(?:6|7|8|9)[\s-]?\d{2}[\s-]?\d{2}[\s-]?\d{2}[\s-]?\d{2}|(?:\+?34[\s-]?)(?:91|93|94|95|96|97|98)[\s-]?\d{3}[\s-]?\d{3}/g;
+    }
+    if ((fieldNamesByType.url || []).length) {
+        leadPatterns.url = /(?:https?:\/\/)?(?:www\.)?[a-zA-Z0-9-]+\.[a-zA-Z]{2,}(?:\/[^\s]*)?/g;
+    }
+
+    const COMMON_EMAIL_DOMAINS = [
+        'gmail.com', 'yahoo.es', 'yahoo.com', 'hotmail.com', 'hotmail.es', 'outlook.com',
+        'outlook.es', 'msn.com', 'live.com', 'aol.com', 'icloud.com', 'me.com', 'mac.com'
+    ];
 
     const leadButtonThreshold = 3;
 
@@ -308,48 +333,135 @@ function renderQuickReplies() {
 
     // --- Funciones de detección de leads ---
     function detectLeadData(message) {
+        if (!message) return false;
+
         let detected = false;
-        
-        const emailMatches = message.match(leadPatterns.email);
-        if (emailMatches && !leadData.email) {
-            leadData.email = emailMatches[0];
-            detected = true;
+
+        if (leadPatterns.email) {
+            const emailMatches = message.match(leadPatterns.email);
+            if (assignFieldMatches(emailMatches, 'email')) {
+                detected = true;
+            }
         }
-        
-        const phoneMatches = message.match(leadPatterns.phone);
-        if (phoneMatches && !leadData.phone) {
-            leadData.phone = phoneMatches[0];
-            detected = true;
+
+        if (leadPatterns.phone) {
+            const phoneMatches = message.match(leadPatterns.phone);
+            if (assignFieldMatches(phoneMatches, 'phone')) {
+                detected = true;
+            }
         }
-        
-        const websiteMatches = message.match(leadPatterns.website);
-        if (websiteMatches && !leadData.website) {
-            leadData.website = websiteMatches[0];
-            detected = true;
+
+        if (leadPatterns.url) {
+            const urlMatches = message.match(leadPatterns.url);
+            if (urlMatches && urlMatches.length) {
+                const filtered = [];
+                urlMatches.forEach((raw) => {
+                    if (!raw) return;
+                    const trimmed = raw.trim();
+                    if (!trimmed || /@/.test(trimmed)) return;
+                    const clean = trimmed.replace(/^(https?:\/\/)?(www\.)?/, '').replace(/\/$/, '');
+                    if (COMMON_EMAIL_DOMAINS.indexOf(clean) !== -1) return;
+                    filtered.push(trimmed);
+                });
+                if (assignFieldMatches(filtered, 'url')) {
+                    detected = true;
+                }
+            }
         }
-        
+
         return detected;
     }
 
-    function checkLeadCompleteness() {
-        const hasContact = leadData.email || leadData.phone;
-
-        if (hasContact) {
-            leadData.isComplete = true;
-            saveLead();
-            return true;
+    function assignFieldMatches(matches, type) {
+        if (!Array.isArray(matches) || !matches.length) {
+            return false;
         }
 
+        const fields = fieldNamesByType[type] || [];
+        if (!fields.length) {
+            return false;
+        }
+
+        let updated = false;
+        const uniqueValues = Array.from(new Set(matches.map((value) => (value || '').trim()).filter(Boolean)));
+
+        uniqueValues.forEach((rawValue) => {
+            if (!rawValue) return;
+
+            for (let i = 0; i < fields.length; i++) {
+                const fieldName = fields[i];
+                if (leadData[fieldName]) {
+                    continue;
+                }
+
+                let normalized = rawValue;
+                if (type === 'url') {
+                    normalized = normalized.replace(/\/$/, '');
+                    if (!/^https?:\/\//i.test(normalized)) {
+                        normalized = `https://${normalized}`;
+                    }
+                } else if (type === 'phone') {
+                    normalized = normalized.replace(/[^0-9+\s\-.()]/g, '');
+                }
+
+                leadData[fieldName] = normalized;
+                updated = true;
+                break;
+            }
+        });
+
+        return updated;
+    }
+
+    function checkLeadCompleteness() {
         const missing = [];
-        if (!leadData.email) missing.push('email');
-        if (!leadData.phone) missing.push('phone');
+
+        requiredFieldNames.forEach((fieldName) => {
+            const value = leadData[fieldName];
+            if (value === null || (typeof value === 'string' && value.trim() === '')) {
+                missing.push(fieldName);
+            }
+        });
+
+        if (missing.length === 0) {
+            const hasAnyData = leadFieldNames.some((fieldName) => {
+                const value = leadData[fieldName];
+                return value !== null && (!(typeof value === 'string') || value.trim() !== '');
+            });
+
+            if (hasAnyData) {
+                leadData.isComplete = true;
+                saveLead();
+                return true;
+            }
+
+            return [];
+        }
 
         return missing;
     }
 
+    function buildLeadPayload() {
+        const payload = { source: leadData.source || 'chatbot_detection', isComplete: true };
+
+        leadFieldNames.forEach((fieldName) => {
+            const value = leadData[fieldName];
+            if (value === null) return;
+            if (typeof value === 'string' && value.trim() === '') return;
+            payload[fieldName] = value;
+        });
+
+        return payload;
+    }
+
     function saveLead() {
         if (!leadData.isComplete) return;
-        
+
+        const payload = buildLeadPayload();
+        if (Object.keys(payload).length <= 2) {
+            return;
+        }
+
         $.ajax({
             url: params.ajax_url,
             type: 'POST',
@@ -358,23 +470,22 @@ function renderQuickReplies() {
                 nonce: params.nonce,
                 log_id: logId,
                 assistant_id: params.assistant_id,
-                lead_data: leadData
+                lead_data: payload
             },
             success: function(response) {
                 if (response.success) {
                     console.log('Lead guardado correctamente');
-                    
+
                     setTimeout(() => {
                         addMessageToChat('bot', "¡Gracias! Hemos capturado tus datos de contacto. Un asesor se pondrá en contacto contigo pronto. ✅");
+                        conversationHistory.push({ role: 'assistant', content: '¡Gracias! Hemos capturado tus datos de contacto. Un asesor se pondrá en contacto contigo pronto. ✅' });
                     }, 500);
 
                     if (params.calendar_url) {
                         setTimeout(() => {
-                            addMessageToChat(
-                                'bot',
-                                '¡Perfecto! Aquí tienes la URL del calendario para que puedas reservar una llamada con nuestro equipo.',
-                                true
-                            );
+                            const calendarMessage = '¡Perfecto! Aquí tienes la URL del calendario para que puedas reservar una llamada con nuestro equipo.';
+                            addMessageToChat('bot', calendarMessage, true);
+                            conversationHistory.push({ role: 'assistant', content: calendarMessage });
                         }, 1500);
                     }
 
@@ -385,6 +496,31 @@ function renderQuickReplies() {
                 console.error('Error al guardar el lead');
             }
         });
+    }
+
+    function askForMissingLeadData(missingFields) {
+        if (!Array.isArray(missingFields) || !missingFields.length) {
+            return;
+        }
+
+        const labels = missingFields.map((field) => {
+            if (leadFieldDefinitions[field]) {
+                return leadFieldDefinitions[field].label || field;
+            }
+            return field;
+        });
+
+        let missingText = labels[0];
+        if (labels.length > 1) {
+            const last = labels.pop();
+            missingText = `${labels.join(', ')} y ${last}`;
+        }
+
+        const prompt = `Para continuar necesito ${missingText}. ¿Puedes compartirlo?`;
+        addMessageToChat('bot', prompt);
+        conversationHistory.push({ role: 'assistant', content: prompt });
+        isCollectingLeadData = true;
+        currentLeadField = missingFields[0];
     }
 
     function showThinkingIndicator() {

--- a/ai-chatbot-pro/includes/class-ajax-handler.php
+++ b/ai-chatbot-pro/includes/class-ajax-handler.php
@@ -198,6 +198,7 @@ class AICP_Ajax_Handler {
         $lead_payload = [];
         if (isset($_POST['lead_data'])) {
             $lead_payload = self::sanitize_lead_payload(wp_unslash($_POST['lead_data']));
+            $lead_payload = AICP_Lead_Manager::sanitize_lead_input($lead_payload, $assistant_id, $s);
         }
 
         $system_prompt = AICP_Prompt_Builder::build($s, $page_context);

--- a/ai-chatbot-pro/includes/class-frontend-loader.php
+++ b/ai-chatbot-pro/includes/class-frontend-loader.php
@@ -99,6 +99,7 @@ class AICP_Frontend_Loader {
         // Obtener configuración adicional
         $lead_auto_collect  = !empty($s['lead_auto_collect']);
         $calendar_url       = !empty($s['calendar_url']) ? esc_url($s['calendar_url']) : '';
+        $lead_fields_config = AICP_Lead_Manager::get_lead_field_config($assistant->ID, $s);
         $auto_open_enabled  = !empty($s['auto_open_enabled']);
         $auto_open_delay    = isset($s['auto_open_delay']) ? max(0, intval($s['auto_open_delay'])) : 0;
         $auto_open_duration = isset($s['auto_open_duration']) ? max(0, intval($s['auto_open_duration'])) : 0;
@@ -121,6 +122,7 @@ class AICP_Frontend_Loader {
 
             'lead_auto_collect'  => $lead_auto_collect,
             'calendar_url'       => $calendar_url,
+            'lead_fields'        => $lead_fields_config,
             'auto_open'          => [
                 'enabled'  => $auto_open_enabled,
                 'delay'    => $auto_open_delay,
@@ -156,16 +158,21 @@ class AICP_Frontend_Loader {
         // Sanitizar datos del lead
         $source = sanitize_text_field($lead_data['source'] ?? 'chatbot_detection');
 
-        $sanitized_lead_data = [
-            'email'        => sanitize_email($lead_data['email'] ?? ''),
-            'name'         => sanitize_text_field($lead_data['name'] ?? ''),
-            'phone'        => sanitize_text_field($lead_data['phone'] ?? ''),
-            'website'      => esc_url_raw($lead_data['website'] ?? ''),
-            'collected_at' => current_time('mysql'),
-            'source'       => $source,
-        ];
+        $assistant_settings = get_post_meta($assistant_id, '_aicp_assistant_settings', true);
+        if (!is_array($assistant_settings)) {
+            $assistant_settings = [];
+        }
 
-        $missing_fields = AICP_Lead_Manager::get_missing_fields($sanitized_lead_data, $assistant_id);
+        $field_definitions = AICP_Lead_Manager::get_lead_field_definitions($assistant_id, $assistant_settings);
+        $sanitized_lead_data = AICP_Lead_Manager::sanitize_lead_input($lead_data, $assistant_id, $assistant_settings, $field_definitions);
+
+        if (empty($sanitized_lead_data)) {
+            wp_send_json_error([
+                'message' => __('No se detectaron datos de contacto válidos.', 'ai-chatbot-pro'),
+            ]);
+        }
+
+        $missing_fields = AICP_Lead_Manager::get_missing_fields($sanitized_lead_data, $assistant_id, $assistant_settings, $field_definitions);
         if (!empty($missing_fields)) {
             wp_send_json_error([
                 'message'        => AICP_Lead_Manager::get_missing_data_message($missing_fields, $assistant_id),
@@ -173,6 +180,8 @@ class AICP_Frontend_Loader {
             ]);
         }
 
+        $sanitized_lead_data['collected_at'] = current_time('mysql');
+        $sanitized_lead_data['source']       = $source;
         $sanitized_lead_data['is_complete'] = true;
 
         global $wpdb;
@@ -229,11 +238,16 @@ class AICP_Frontend_Loader {
         global $wpdb;
         $table = $wpdb->prefix . 'aicp_chat_logs';
 
+        $lead_payload = $lead_info['data'];
+        if (!isset($lead_payload['captured_at'])) {
+            $lead_payload['captured_at'] = current_time('mysql');
+        }
+
         $updated = $wpdb->update(
             $table,
             [
                 'has_lead'   => 1,
-                'lead_data'  => wp_json_encode($lead_info['data'], JSON_UNESCAPED_UNICODE),
+                'lead_data'  => wp_json_encode($lead_payload, JSON_UNESCAPED_UNICODE),
                 'lead_status'=> 'complete'
             ],
             ['id' => $log_id],
@@ -242,8 +256,8 @@ class AICP_Frontend_Loader {
         );
 
         if ($updated !== false) {
-            do_action('aicp_lead_detected', $lead_info['data'], $assistant_id, $log_id, 'complete');
-            wp_send_json_success(['lead' => $lead_info['data']]);
+            do_action('aicp_lead_detected', $lead_payload, $assistant_id, $log_id, 'complete');
+            wp_send_json_success(['lead' => $lead_payload]);
         } else {
             wp_send_json_error(['message' => __('Error al guardar el lead.', 'ai-chatbot-pro')]);
         }

--- a/ai-chatbot-pro/includes/class-lead-manager.php
+++ b/ai-chatbot-pro/includes/class-lead-manager.php
@@ -10,7 +10,7 @@ if (!defined('ABSPATH')) {
 }
 
 class AICP_Lead_Manager {
-    
+
     /**
      * Patrones para detectar emails, teléfonos y URLs
      */
@@ -21,6 +21,116 @@ class AICP_Lead_Manager {
         '/\b\d{3}[ -]?\d{3}[ -]?\d{3}\b/', // Formato simple
     ];
     private static $url_pattern = '/(https?:\/\/)?([\w\-]+\.)+[\w\-]+(\/[\w\-._~:\/?#[\]@!$&\'()*+,;=]*)?/';
+
+    /**
+     * Sanitizar un valor de campo en función de su tipo
+     */
+    private static function sanitize_field_value($value, $type) {
+        if (is_array($value)) {
+            $value = implode(', ', array_map('sanitize_text_field', $value));
+        }
+
+        $value = is_scalar($value) ? (string) $value : '';
+
+        switch ($type) {
+            case 'email':
+                return sanitize_email($value);
+            case 'url':
+            case 'website':
+                return esc_url_raw($value);
+            case 'phone':
+                $clean = preg_replace('/[^0-9+\s\-().]/', '', $value);
+                return sanitize_text_field($clean);
+            case 'number':
+                return is_numeric($value) ? (string) $value : sanitize_text_field($value);
+            case 'textarea':
+            case 'date':
+            case 'text':
+            default:
+                return sanitize_text_field($value);
+        }
+    }
+
+    /**
+     * Sanitizar el conjunto de datos de un lead en base a la configuración del asistente
+     */
+    public static function sanitize_lead_input($lead_input, $assistant_id = 0, $assistant_settings = null, $field_definitions = null) {
+        $lead_input = is_array($lead_input) ? $lead_input : [];
+
+        if ($field_definitions === null) {
+            $field_definitions = self::get_lead_field_definitions($assistant_id, $assistant_settings);
+        }
+
+        $sanitized = [];
+        foreach ($field_definitions as $name => $definition) {
+            if (!array_key_exists($name, $lead_input)) {
+                continue;
+            }
+
+            $value = self::sanitize_field_value($lead_input[$name], $definition['type']);
+            if ($value !== '' && $value !== null) {
+                $sanitized[$name] = $value;
+            }
+        }
+
+        return $sanitized;
+    }
+
+    /**
+     * Extraer payloads estructurados de leads presentes en un contenido
+     */
+    private static function extract_structured_lead_payloads($content) {
+        $payloads = [];
+
+        if (!is_string($content) || strpos($content, '{') === false) {
+            return $payloads;
+        }
+
+        if (preg_match_all('/\{(?:[^{}]|(?R))*\}/m', $content, $matches)) {
+            foreach ($matches[0] as $json_candidate) {
+                $decoded = json_decode($json_candidate, true);
+                if (json_last_error() !== JSON_ERROR_NONE) {
+                    continue;
+                }
+                self::collect_structured_payloads($decoded, $payloads);
+            }
+        }
+
+        return $payloads;
+    }
+
+    /**
+     * Recoger datos de lead de estructuras anidadas
+     */
+    private static function collect_structured_payloads($decoded, &$payloads) {
+        if (!is_array($decoded)) {
+            return;
+        }
+
+        if (isset($decoded['action']) && is_string($decoded['action']) && 'create_lead' === strtolower($decoded['action'])) {
+            $data = [];
+            if (isset($decoded['data']) && is_array($decoded['data'])) {
+                $data = $decoded['data'];
+            } else {
+                $data = $decoded;
+                unset($data['action']);
+            }
+
+            if (!empty($data)) {
+                $payloads[] = $data;
+            }
+        }
+
+        if (isset($decoded['create_lead']) && is_array($decoded['create_lead'])) {
+            $payloads[] = $decoded['create_lead'];
+        }
+
+        foreach ($decoded as $value) {
+            if (is_array($value)) {
+                self::collect_structured_payloads($value, $payloads);
+            }
+        }
+    }
     
     /**
      * Inicializar la clase
@@ -49,7 +159,6 @@ class AICP_Lead_Manager {
         $field_definitions = self::get_lead_field_definitions($assistant_id, $assistant_settings);
         $required_fields   = self::extract_required_field_names($field_definitions);
         $lead_data         = [];
-        $has_partial_data  = false;
 
         if (!is_array($conversation)) {
             return [
@@ -63,58 +172,108 @@ class AICP_Lead_Manager {
         $user_messages = array_filter($conversation, function($message) {
             return isset($message['role']) && $message['role'] === 'user';
         });
-        $user_text = implode("\n", array_column($user_messages, 'content'));
-        $common_email_domains = [
-            'gmail.com', 'yahoo.es', 'yahoo.com', 'hotmail.com', 'hotmail.es', 'outlook.com',
-            'outlook.es', 'msn.com', 'live.com', 'aol.com', 'icloud.com', 'me.com', 'mac.com'
-        ];
+        $assistant_messages = array_filter($conversation, function($message) {
+            return isset($message['role']) && $message['role'] === 'assistant';
+        });
 
-        if (preg_match(self::$email_pattern, $user_text, $matches)) {
-            $lead_data['email'] = sanitize_email($matches[0]);
-            $has_partial_data   = true;
-        }
-
-        if (!isset($lead_data['phone'])) {
-            foreach (self::$phone_patterns as $pattern) {
-                if (preg_match($pattern, $user_text, $matches)) {
-                    $phone = preg_replace('/[^\d+]/', '', $matches[0]);
-                    if (strlen($phone) >= 9) {
-                        $lead_data['phone'] = sanitize_text_field($matches[0]);
-                        $has_partial_data   = true;
-                        break;
-                    }
+        foreach ($assistant_messages as $message) {
+            $content = isset($message['content']) ? $message['content'] : '';
+            foreach (self::extract_structured_lead_payloads($content) as $payload) {
+                $structured_data = self::sanitize_lead_input($payload, $assistant_id, $assistant_settings, $field_definitions);
+                if (!empty($structured_data)) {
+                    $lead_data = array_merge($lead_data, $structured_data);
                 }
             }
         }
 
-        if (preg_match_all(self::$url_pattern, $user_text, $matches)) {
-            foreach ($matches[0] as $potential_url) {
-                $cleaned_url = preg_replace('/^(https?:\/\/)?(www\.)?/', '', rtrim($potential_url, '/'));
+        $user_text = implode("\n", array_column($user_messages, 'content'));
+        $fields_by_type = [];
+        foreach ($field_definitions as $name => $definition) {
+            $type = $definition['type'];
+            if ($type === 'website') {
+                $type = 'url';
+            }
+            if (!isset($fields_by_type[$type])) {
+                $fields_by_type[$type] = [];
+            }
+            $fields_by_type[$type][] = $name;
+        }
 
-                if (!in_array($cleaned_url, $common_email_domains)) {
+        $assignFirstAvailable = function($matches, $type) use (&$lead_data, $field_definitions, $fields_by_type) {
+            if (empty($matches) || empty($fields_by_type[$type])) {
+                return;
+            }
+
+            foreach ($matches as $value) {
+                foreach ($fields_by_type[$type] as $field_name) {
+                    if (!empty($lead_data[$field_name])) {
+                        continue;
+                    }
+
+                    $sanitized = self::sanitize_field_value($value, $field_definitions[$field_name]['type']);
+                    if ($sanitized !== '' && $sanitized !== null) {
+                        $lead_data[$field_name] = $sanitized;
+                        continue 2;
+                    }
+                }
+            }
+        };
+
+        if (!empty($fields_by_type['email']) && preg_match_all(self::$email_pattern, $user_text, $email_matches)) {
+            $assignFirstAvailable(array_unique($email_matches[0]), 'email');
+        }
+
+        if (!empty($fields_by_type['phone'])) {
+            foreach (self::$phone_patterns as $pattern) {
+                if (preg_match_all($pattern, $user_text, $phone_matches)) {
+                    $assignFirstAvailable(array_unique($phone_matches[0]), 'phone');
+                    break;
+                }
+            }
+        }
+
+        if (!empty($fields_by_type['url']) || !empty($fields_by_type['website'])) {
+            if (preg_match_all(self::$url_pattern, $user_text, $url_matches)) {
+                $common_email_domains = [
+                    'gmail.com', 'yahoo.es', 'yahoo.com', 'hotmail.com', 'hotmail.es', 'outlook.com',
+                    'outlook.es', 'msn.com', 'live.com', 'aol.com', 'icloud.com', 'me.com', 'mac.com'
+                ];
+                $urls = [];
+                foreach ($url_matches[0] as $potential_url) {
+                    $cleaned_url = preg_replace('/^(https?:\/\/)?(www\.)?/', '', rtrim($potential_url, '/'));
+                    if (in_array($cleaned_url, $urls, true) || in_array($cleaned_url, $common_email_domains, true)) {
+                        continue;
+                    }
+
                     $url = $potential_url;
                     if (!preg_match('/^https?:\/\//', $url)) {
                         $url = 'https://' . $url;
                     }
+
                     if (filter_var($url, FILTER_VALIDATE_URL)) {
-                        $lead_data['website'] = esc_url_raw($url);
-                        $has_partial_data     = true;
-                        break;
+                        $urls[] = $url;
                     }
+                }
+
+                if (!empty($urls)) {
+                    $type_key = !empty($fields_by_type['url']) ? 'url' : 'website';
+                    $assignFirstAvailable($urls, $type_key);
                 }
             }
         }
 
-        if (!isset($lead_data['name'])) {
+        if (isset($field_definitions['name']) && empty($lead_data['name'])) {
             $name = self::extract_name($user_text);
             if ($name) {
-                $lead_data['name'] = sanitize_text_field($name);
-                $has_partial_data  = true;
+                $lead_data['name'] = self::sanitize_field_value($name, $field_definitions['name']['type']);
             }
         }
 
+        $lead_data = self::sanitize_lead_input($lead_data, $assistant_id, $assistant_settings, $field_definitions);
         $lead_data = array_intersect_key($lead_data, $field_definitions);
+
         $missing_fields = self::get_missing_fields($lead_data, $assistant_id, $assistant_settings, $field_definitions);
+        $has_partial_data = !empty($lead_data);
         $is_complete    = $has_partial_data && empty($missing_fields);
 
         return [
@@ -168,11 +327,16 @@ class AICP_Lead_Manager {
         global $wpdb;
         $table_name = $wpdb->prefix . 'aicp_chat_logs';
 
+        $lead_payload = $lead_info['data'];
+        if (!isset($lead_payload['captured_at'])) {
+            $lead_payload['captured_at'] = current_time('mysql');
+        }
+
         $wpdb->update(
             $table_name,
             [
                 'has_lead'    => 1,
-                'lead_data'   => wp_json_encode($lead_info['data'], JSON_UNESCAPED_UNICODE),
+                'lead_data'   => wp_json_encode($lead_payload, JSON_UNESCAPED_UNICODE),
                 'lead_status' => 'complete'
             ],
             ['id' => $log_id],
@@ -180,7 +344,7 @@ class AICP_Lead_Manager {
             ['%d']
         );
 
-        do_action('aicp_lead_detected', $lead_info['data'], $assistant_id, $log_id, 'complete');
+        do_action('aicp_lead_detected', $lead_payload, $assistant_id, $log_id, 'complete');
     }
 
     private static function get_lead_field_definitions($assistant_id = 0, $assistant_settings = null) {
@@ -237,23 +401,7 @@ class AICP_Lead_Manager {
             ];
         }
 
-        $definitions = array_merge($defaults, $normalized);
-
-        $has_required = false;
-        foreach ($definitions as $definition) {
-            if (!empty($definition['required'])) {
-                $has_required = true;
-                break;
-            }
-        }
-
-        if (!$has_required) {
-            foreach ($definitions as $name => $definition) {
-                $definitions[$name]['required'] = true;
-            }
-        }
-
-        return $definitions;
+        return array_merge($defaults, $normalized);
     }
 
     private static function extract_required_field_names($field_definitions) {
@@ -479,6 +627,21 @@ class AICP_Lead_Manager {
         }
 
         return $stats;
+    }
+
+    public static function get_lead_field_config($assistant_id = 0, $assistant_settings = null) {
+        $definitions = self::get_lead_field_definitions($assistant_id, $assistant_settings);
+        $config = [];
+
+        foreach ($definitions as $name => $definition) {
+            $config[$name] = [
+                'label'    => $definition['label'],
+                'required' => !empty($definition['required']),
+                'type'     => $definition['type'],
+            ];
+        }
+
+        return $config;
     }
 
     public static function get_missing_data_message($missing_fields, $assistant_id = 0, $assistant_settings = null) {

--- a/ai-chatbot-pro/includes/class-shortcode-handler.php
+++ b/ai-chatbot-pro/includes/class-shortcode-handler.php
@@ -83,6 +83,7 @@ class AICP_Shortcode_Handler {
         $auto_open_delay    = isset($s['auto_open_delay']) ? max(0, intval($s['auto_open_delay'])) : 0;
         $auto_open_duration = isset($s['auto_open_duration']) ? max(0, intval($s['auto_open_duration'])) : 0;
         $auto_open_message  = isset($s['auto_open_message']) ? sanitize_textarea_field($s['auto_open_message']) : '';
+        $lead_fields_config = AICP_Lead_Manager::get_lead_field_config($assistant_id, $s);
 
         wp_localize_script('aicp-chatbot-script', 'aicp_chatbot_params', [
             'ajax_url'           => admin_url('admin-ajax.php'),
@@ -100,6 +101,7 @@ class AICP_Shortcode_Handler {
 
             'lead_auto_collect'  => $lead_auto_collect,
             'calendar_url'       => $calendar_url,
+            'lead_fields'        => $lead_fields_config,
             'auto_open'          => [
                 'enabled'  => $auto_open_enabled,
                 'delay'    => $auto_open_delay,


### PR DESCRIPTION
## Summary
- allow assistants to define and sanitize custom lead fields, parse structured lead payloads, and only mark completion when required data is present
- surface lead field configuration to the frontend and admin UIs so the chatbot can pursue mandatory fields, prompt for missing data, and display labels in the lead history
- disable the lead configuration controls when the n8n integration is active and harden manual lead capture to record timestamps and validate payloads

## Testing
- php -l ai-chatbot-pro/includes/class-lead-manager.php
- php -l ai-chatbot-pro/includes/class-frontend-loader.php
- php -l ai-chatbot-pro/includes/class-shortcode-handler.php
- php -l ai-chatbot-pro/includes/class-ajax-handler.php

------
https://chatgpt.com/codex/tasks/task_e_68f232f9195883308e8c1e080579cc6a