### PR TITLE
Harden lead flow and gate PRO training when webhook forwarding

### DIFF
--- a/ai-chatbot-pro/assets/js/admin-scripts.js
+++ b/ai-chatbot-pro/assets/js/admin-scripts.js
@@ -327,6 +327,134 @@ jQuery(function($) {
         }
     }
 
+    function handleProTrainingLock() {
+        const $container = $('.aicp-pro-training-fields');
+        if (!$container.length) {
+            return;
+        }
+
+        const $notice = $('.aicp-pro-training-lock-notice');
+        const $toggle = $('#aicp_forward_to_webhook');
+        const $lockableElements = $container.find('input, textarea, select, button').filter(function() {
+            const $el = $(this);
+            const type = ($el.attr('type') || '').toLowerCase();
+            return type !== 'hidden';
+        });
+
+        let isLocked = false;
+
+        function createHiddenMirror($el) {
+            const name = $el.attr('name');
+            if (!name) {
+                return null;
+            }
+
+            let $hidden = $el.data('aicpLockHidden');
+            if (!$hidden || !$hidden.length) {
+                $hidden = $('<input type="hidden" class="aicp-lock-hidden" />').attr('name', name);
+                $el.after($hidden);
+                $el.data('aicpLockHidden', $hidden);
+            }
+
+            if ($el.is(':checkbox') || $el.is(':radio')) {
+                $hidden.val($el.is(':checked') ? ($el.val() || 'on') : '');
+            } else if ($el.is('select')) {
+                $hidden.val($el.val());
+            }
+
+            return $hidden;
+        }
+
+        function removeHiddenMirror($el) {
+            const $hidden = $el.data('aicpLockHidden');
+            if ($hidden && $hidden.length) {
+                $hidden.remove();
+                $el.removeData('aicpLockHidden');
+            }
+        }
+
+        function lockElement($el) {
+            const type = ($el.attr('type') || '').toLowerCase();
+            if ($el.is('textarea') || ($el.is('input') && !['checkbox', 'radio', 'button', 'submit'].includes(type))) {
+                if (typeof $el.data('aicpOriginalReadonly') === 'undefined') {
+                    $el.data('aicpOriginalReadonly', $el.prop('readonly'));
+                }
+                $el.prop('readonly', true);
+            }
+
+            if ($el.is('select') || $el.is(':checkbox') || $el.is(':radio') || $el.is('button')) {
+                if (typeof $el.data('aicpOriginalDisabled') === 'undefined') {
+                    $el.data('aicpOriginalDisabled', $el.prop('disabled'));
+                }
+                $el.prop('disabled', true);
+                if (!$el.is('button')) {
+                    createHiddenMirror($el);
+                }
+            }
+        }
+
+        function unlockElement($el) {
+            const type = ($el.attr('type') || '').toLowerCase();
+            if ($el.is('textarea') || ($el.is('input') && !['checkbox', 'radio', 'button', 'submit'].includes(type))) {
+                if (typeof $el.data('aicpOriginalReadonly') !== 'undefined') {
+                    $el.prop('readonly', $el.data('aicpOriginalReadonly'));
+                } else {
+                    $el.prop('readonly', false);
+                }
+            }
+
+            if ($el.is('select') || $el.is(':checkbox') || $el.is(':radio') || $el.is('button')) {
+                if (typeof $el.data('aicpOriginalDisabled') !== 'undefined') {
+                    $el.prop('disabled', $el.data('aicpOriginalDisabled'));
+                } else {
+                    $el.prop('disabled', false);
+                }
+                if (!$el.is('button')) {
+                    removeHiddenMirror($el);
+                }
+            }
+        }
+
+        function setLocked(locked) {
+            if (locked === isLocked) {
+                return;
+            }
+
+            isLocked = locked;
+
+            if (locked) {
+                $container.addClass('aicp-pro-training-fields--locked');
+                $notice.show();
+            } else {
+                $container.removeClass('aicp-pro-training-fields--locked');
+                $notice.hide();
+            }
+
+            $lockableElements.each(function() {
+                const $el = $(this);
+                if ($el.hasClass('aicp-lock-hidden')) {
+                    return;
+                }
+                if (locked) {
+                    lockElement($el);
+                } else {
+                    unlockElement($el);
+                }
+            });
+        }
+
+        const initialLocked = $container.data('forwarding-active') === 1 || ($toggle.length && ($toggle.is(':checked') || !!(aicp_admin_params.initial_settings && aicp_admin_params.initial_settings.forward_to_webhook)));
+        if (initialLocked) {
+            setLocked(true);
+        }
+
+        if ($toggle.length) {
+            $toggle.on('change', function() {
+                setLocked($toggle.is(':checked'));
+            });
+        }
+    }
+
 
     function handleLivePreview(element, value) {
         const $el = $(element);
@@ -484,6 +612,7 @@ jQuery(function($) {
         initTemplateSelector();
         handleCustomPromptToggle();
         handleWebhookToggle();
+        handleProTrainingLock();
 
     }
 });

--- a/ai-chatbot-pro/includes/class-ajax-handler.php
+++ b/ai-chatbot-pro/includes/class-ajax-handler.php
@@ -448,8 +448,22 @@ class AICP_Ajax_Handler {
             wp_send_json_error(['message' => __('Datos incompletos.', 'ai-chatbot-pro')]);
         }
 
-        do_action('aicp_lead_detected', $answers, $assistant_id, 0, 'form');
+        $missing_fields = AICP_Lead_Manager::get_missing_fields($answers, $assistant_id);
+        $lead_status    = empty($missing_fields) ? 'complete' : 'incomplete';
 
-        wp_send_json_success(['message' => __('Formulario enviado', 'ai-chatbot-pro')]);
+        if ($lead_status === 'complete') {
+            do_action('aicp_lead_detected', $answers, $assistant_id, 0, 'complete');
+        }
+
+        $response = [
+            'message' => __('Formulario enviado', 'ai-chatbot-pro'),
+            'status'  => $lead_status,
+        ];
+
+        if ($lead_status !== 'complete') {
+            $response['missing_fields'] = $missing_fields;
+        }
+
+        wp_send_json_success($response);
     }
 }

--- a/ai-chatbot-pro/includes/class-lead-manager.php
+++ b/ai-chatbot-pro/includes/class-lead-manager.php
@@ -444,6 +444,10 @@ class AICP_Lead_Manager {
      * Enviar los datos del lead a la URL configurada.
      */
     public static function send_lead_to_webhook($lead_data, $assistant_id, $log_id, $lead_status) {
+        if ($lead_status !== 'complete') {
+            return;
+        }
+
         $settings = get_post_meta($assistant_id, '_aicp_assistant_settings', true);
         $url = isset($settings['webhook_url']) ? esc_url_raw($settings['webhook_url']) : '';
 
@@ -473,6 +477,10 @@ class AICP_Lead_Manager {
      * Enviar notificación por email con los datos del lead.
      */
     public static function email_lead_notification($lead_data, $assistant_id, $log_id, $lead_status) {
+        if ($lead_status !== 'complete') {
+            return;
+        }
+
         $settings = get_post_meta($assistant_id, '_aicp_assistant_settings', true);
         $email    = isset($settings['lead_email']) ? sanitize_email($settings['lead_email']) : '';
         if (!$email) {

--- a/ai-chatbot-pro/includes/class-prompt-builder.php
+++ b/ai-chatbot-pro/includes/class-prompt-builder.php
@@ -23,65 +23,73 @@ class AICP_Prompt_Builder {
     }
 
     public static function build($settings, $page_context = '') {
-        // Si el usuario ha habilitado la edición manual, usamos ese prompt directamente.
-        if (isset($settings['custom_prompt']) && !empty($settings['custom_prompt'])) {
-            return $settings['custom_prompt'];
-        }
+        $forwarding_enabled = !empty($settings['forward_to_webhook']);
+        $behavior_rules     = isset($settings['behavior_rules']) ? trim($settings['behavior_rules']) : '';
+        $append_behavior    = !$forwarding_enabled && $behavior_rules !== '';
 
-        $parts = [];
-        $template_id = $settings['template_id'] ?? '';
-        
-        // Cargar plantilla si existe
-        if ($template_id) {
-            $template = self::get_template($template_id);
-            if ($template && !empty($template['system_prompt_template'])) {
-                // Preparar datos para los placeholders de la plantilla
-                $meta = [
-                    'brand'          => function_exists('get_option') ? get_option('aicp_brand', '') : '',
-                    'domain'         => function_exists('get_option') ? get_option('aicp_domain', '') : '',
-                    'services'       => function_exists('get_option') ? implode(', ', (array) get_option('aicp_services', [])) : '',
-                    'pricing_ranges' => function_exists('get_option') ? (array) get_option('aicp_pricing_ranges', []) : [],
-                    'timezone'       => function_exists('wp_timezone_string') ? wp_timezone_string() : 'UTC',
-                ];
-                // Los placeholders de pricing_ranges necesitan un tratamiento especial en el template
-                foreach ($meta['pricing_ranges'] as $key => $value) {
-                    $meta['pricing_ranges.' . $key] = $value;
-                }
-                
-                if (function_exists('aicp_render_template')) {
-                    $parts[] = aicp_render_template($template['system_prompt_template'], $meta);
-                } else {
-                    $parts[] = $template['system_prompt_template'];
+        $prompt = '';
+
+        if (isset($settings['custom_prompt']) && !empty($settings['custom_prompt'])) {
+            $prompt = $settings['custom_prompt'];
+        } else {
+            $parts = [];
+            $template_id = $settings['template_id'] ?? '';
+
+            if ($template_id) {
+                $template = self::get_template($template_id);
+                if ($template && !empty($template['system_prompt_template'])) {
+                    $meta = [
+                        'brand'          => function_exists('get_option') ? get_option('aicp_brand', '') : '',
+                        'domain'         => function_exists('get_option') ? get_option('aicp_domain', '') : '',
+                        'services'       => function_exists('get_option') ? implode(', ', (array) get_option('aicp_services', [])) : '',
+                        'pricing_ranges' => function_exists('get_option') ? (array) get_option('aicp_pricing_ranges', []) : [],
+                        'timezone'       => function_exists('wp_timezone_string') ? wp_timezone_string() : 'UTC',
+                    ];
+
+                    foreach ($meta['pricing_ranges'] as $key => $value) {
+                        $meta['pricing_ranges.' . $key] = $value;
+                    }
+
+                    if (function_exists('aicp_render_template')) {
+                        $parts[] = aicp_render_template($template['system_prompt_template'], $meta);
+                    } else {
+                        $parts[] = $template['system_prompt_template'];
+                    }
                 }
             }
-        }
- 
-        // Añadir campos individuales solo si la plantilla no está seleccionada o si queremos un sistema mixto
-        // En este caso, la plantilla se considera el prompt principal y los campos son modificadores.
-        // La lógica actual ya los une. Solo hay que asegurarse de que no dupliquen información.
-        // Si la plantilla ya tiene una persona, la sobrescribimos con el campo manual.
-        if (!empty($settings['persona'])) {
-            $parts[] = 'PERSONALIDAD: ' . $settings['persona'];
-        }
-        if (!empty($settings['objective'])) {
-            $parts[] = 'OBJETIVO PRINCIPAL: ' . $settings['objective'];
-        }
-        if (!empty($settings['length_tone'])) {
-            $parts[] = 'TONO Y LONGITUD: ' . $settings['length_tone'];
-        }
-        if (!empty($settings['example'])) {
-            $parts[] = 'EJEMPLO DE RESPUESTA: ' . $settings['example'];
+
+            if (!empty($settings['persona'])) {
+                $parts[] = 'PERSONALIDAD: ' . $settings['persona'];
+            }
+            if (!empty($settings['objective'])) {
+                $parts[] = 'OBJETIVO PRINCIPAL: ' . $settings['objective'];
+            }
+            if (!empty($settings['length_tone'])) {
+                $parts[] = 'TONO Y LONGITUD: ' . $settings['length_tone'];
+            }
+            if (!empty($settings['example'])) {
+                $parts[] = 'EJEMPLO DE RESPUESTA: ' . $settings['example'];
+            }
+
+            if (!empty($page_context)) {
+                $parts[] = "--- INICIO DEL CONTEXTO DE LA PÁGINA ACTUAL ---\n" . $page_context . "\n--- FIN DEL CONTEXTO ---";
+                $parts[] = 'Responde a las preguntas del usuario basándote en el contexto de la página proporcionado. Si la información no está en el contexto, indícalo amablemente.';
+            }
+
+            $prompt = implode("\n\n", $parts);
         }
 
-        if (!empty($page_context)) {
-            $parts[] = "--- INICIO DEL CONTEXTO DE LA PÁGINA ACTUAL ---\n" . $page_context . "\n--- FIN DEL CONTEXTO ---";
-            $parts[] = 'Responde a las preguntas del usuario basándote en el contexto de la página proporcionado. Si la información no está en el contexto, indícalo amablemente.';
+        $prompt = trim($prompt);
+
+        if ($append_behavior) {
+            $behavior_block = "== REGLAS DE COMPORTAMIENTO (Filtro Adicional) ==\n" . $behavior_rules;
+            $prompt = $prompt === '' ? $behavior_block : $prompt . "\n\n" . $behavior_block;
         }
 
-        $prompt = implode("\n\n", $parts);
-        if (empty($prompt)) {
+        if ($prompt === '') {
             $prompt = 'Eres un asistente de IA.';
         }
+
         return $prompt;
     }
 }

--- a/aicp-advanced-training/includes/class-pro-features.php
+++ b/aicp-advanced-training/includes/class-pro-features.php
@@ -21,6 +21,7 @@ class AICP_Pro_Features {
         $auto_open_delay = isset($settings['auto_open_delay']) ? absint($settings['auto_open_delay']) : 5;
         $auto_open_duration = isset($settings['auto_open_duration']) ? absint($settings['auto_open_duration']) : 0;
         $auto_open_message = isset($settings['auto_open_message']) ? $settings['auto_open_message'] : '';
+        $integration_active = !empty($settings['forward_to_webhook']);
         
         // --- INICIO DE LA MODIFICACIÓN ---
         // Obtener las reglas de comportamiento guardadas
@@ -53,6 +54,10 @@ class AICP_Pro_Features {
         }
 
         ?>
+        <div class="notice notice-warning inline aicp-pro-training-lock-notice" <?php if (!$integration_active) : ?>style="display:none;"<?php endif; ?>>
+            <p><?php _e('La integración con n8n está activa. Desactívala para volver a entrenar el asistente o modificar estas opciones PRO.', 'ai-chatbot-pro'); ?></p>
+        </div>
+        <div class="aicp-pro-training-fields" data-forwarding-active="<?php echo $integration_active ? '1' : '0'; ?>">
         <h4><?php _e('Entrenamiento de Contenido (con OpenAI)', 'ai-chatbot-pro'); ?></h4>
         <p class="description"><?php _e('Selecciona el contenido de tu web para crear una base de conocimiento directamente en OpenAI. El asistente usará esta información para responder.', 'ai-chatbot-pro'); ?></p>
 
@@ -143,6 +148,7 @@ class AICP_Pro_Features {
             <p style="margin: 5px 0;"><?php if ($last_sync_time) : ?>Última sincronización: <?php echo date_i18n(get_option('date_format') . ' H:i', $last_sync_time); ?> (<?php echo esc_html($last_sync_count); ?> posts/páginas procesados).<?php else: ?>Este asistente no se ha sincronizado nunca.<?php endif; ?></p>
             <small>OpenAI Assistant ID: <?php echo esc_html($openai_assistant_id ?: 'N/A'); ?></small><br>
             <small>OpenAI Vector Store ID: <?php echo esc_html($vector_store_id ?: 'N/A'); ?></small>
+        </div>
         </div>
         <?php
     }


### PR DESCRIPTION
## Summary
- require complete lead data before dispatching webhook/email notifications and return status details from manual lead forms
- append the PRO behavior rules into live prompts whenever webhook forwarding is inactive
- lock the PRO training interface whenever forwarding is enabled so settings stay read-only on the assistant screen

## Testing
- php -l ai-chatbot-pro/includes/class-ajax-handler.php
- php -l ai-chatbot-pro/includes/class-lead-manager.php
- php -l ai-chatbot-pro/includes/class-prompt-builder.php
- php -l aicp-advanced-training/includes/class-pro-features.php

------
https://chatgpt.com/codex/tasks/task_e_68f2390940a0833084c836fecd2cde04