### PR TITLE
Lock assistant configuration when forwarding to webhooks

### DIFF
--- a/ai-chatbot-pro/admin/assistant-meta-boxes.php
+++ b/ai-chatbot-pro/admin/assistant-meta-boxes.php
@@ -139,6 +139,16 @@ function aicp_render_main_meta_box($post) {
     wp_nonce_field('aicp_save_meta_box_data', 'aicp_meta_box_nonce');
     $v = get_post_meta($post->ID, '_aicp_assistant_settings', true);
     if (!is_array($v)) $v = [];
+    $forwarding_active = !empty($v['forward_to_webhook']) && !empty($v['forward_webhook_url']);
+    $leads_tab_classes = 'aicp-tab-content';
+    if ($forwarding_active) {
+        $leads_tab_classes .= ' aicp-leads-tab--locked';
+    }
+
+    $pro_tab_classes = 'aicp-tab-content';
+    if ($forwarding_active) {
+        $pro_tab_classes .= ' aicp-pro-tab--locked';
+    }
     ?>
     <div id="aicp-tab-instructions" class="aicp-tab-content">
         <?php aicp_render_instructions_tab($v); ?>
@@ -153,7 +163,7 @@ function aicp_render_main_meta_box($post) {
             </div>
         </div>
     </div>
-    <div id="aicp-tab-leads" class="aicp-tab-content" style="display:none;">
+    <div id="aicp-tab-leads" class="<?php echo esc_attr($leads_tab_classes); ?>" style="display:none;" data-forwarding-active="<?php echo $forwarding_active ? '1' : '0'; ?>">
         <?php aicp_render_leads_tab($post->ID, $v); ?>
     </div>
     <div id="aicp-tab-integrations" class="aicp-tab-content" style="display:none;">
@@ -162,13 +172,16 @@ function aicp_render_main_meta_box($post) {
 
     <?php // Lógica corregida y limpia para mostrar el contenido PRO o el mensaje de venta.
     if (class_exists('AICP_Pro_Features')) : ?>
-        <div id="aicp-tab-pro" class="aicp-tab-content" style="display:none;">
-            <?php 
-            do_action('aicp_pro_tab_content'); 
+        <div id="aicp-tab-pro" class="<?php echo esc_attr($pro_tab_classes); ?>" style="display:none;" data-forwarding-active="<?php echo $forwarding_active ? '1' : '0'; ?>">
+            <div class="notice notice-warning inline aicp-pro-lock-notice"<?php echo $forwarding_active ? '' : ' style="display:none;"'; ?>>
+                <p><?php _e('Las funciones PRO están bloqueadas porque el asistente está reenviando los mensajes a un webhook externo. Desactiva la integración para realizar cambios.', 'ai-chatbot-pro'); ?></p>
+            </div>
+            <?php
+            do_action('aicp_pro_tab_content');
             ?>
         </div>
     <?php else: ?>
-        <div id="aicp-tab-pro-upsell" class="aicp-tab-content" style="display:none;">
+        <div id="aicp-tab-pro-upsell" class="<?php echo esc_attr($pro_tab_classes); ?>" style="display:none;" data-forwarding-active="<?php echo $forwarding_active ? '1' : '0'; ?>">
             <?php aicp_render_pro_upsell(); ?>
         </div>
     <?php endif; ?>
@@ -313,12 +326,15 @@ function aicp_render_leads_tab($assistant_id, $v) {
 
     echo '<h4>' . __('Ajustes de Captura de Leads', 'ai-chatbot-pro') . '</h4>';
 
+    $notice_style = $integration_active ? '' : ' style="display:none;"';
+    echo '<div class="notice notice-warning inline aicp-leads-lock-notice"' . $notice_style . '><p>' . __('Las opciones de leads están bloqueadas porque el asistente está reenviando los mensajes a un webhook externo. Desactiva la integración para modificar estos ajustes.', 'ai-chatbot-pro') . '</p></div>';
+
+    $fieldset_classes = 'aicp-lead-settings';
     if ($integration_active) {
-        echo '<div class="notice notice-warning inline"><p>' . __('La integración con n8n está activa. Desactívala para configurar la captura de leads desde este apartado.', 'ai-chatbot-pro') . '</p></div>';
+        $fieldset_classes .= ' aicp-lead-settings--locked';
     }
 
-    $fieldset_attr = $integration_active ? ' disabled="disabled"' : '';
-    echo '<fieldset class="aicp-lead-settings"' . $fieldset_attr . '>';
+    echo '<fieldset class="' . esc_attr($fieldset_classes) . '">';
     echo '<table class="form-table"><tbody>';
     echo '<tr><th><label>' . __('Captura Automática', 'ai-chatbot-pro') . '</label></th><td><label><input type="checkbox" name="aicp_settings[lead_auto_collect]" value="1" ' . checked($auto_collect, true, false) . '> ' . __('Solicitar datos de contacto automáticamente', 'ai-chatbot-pro') . '</label></td></tr>';
     echo '<tr><th><label for="aicp_lead_email">' . __('Email de notificación', 'ai-chatbot-pro') . '</label></th><td><input type="email" id="aicp_lead_email" name="aicp_settings[lead_email]" value="' . esc_attr($lead_email) . '" class="regular-text" /><br /><span class="description">' . sprintf(__('Si se deja vacío, se usará %s.', 'ai-chatbot-pro'), esc_html(get_option('admin_email'))) . '</span></td></tr>';
@@ -457,31 +473,67 @@ function aicp_save_meta_box_data($post_id) {
     $current = get_post_meta($post_id, '_aicp_assistant_settings', true);
     if (!is_array($current)) $current = [];
 
-    // Instrucciones
-    if (isset($s['model'])) {
-        $model = sanitize_text_field($s['model']);
-        $current['model'] = array_key_exists($model, AICP_AVAILABLE_MODELS) ? $model : array_key_first(AICP_AVAILABLE_MODELS);
-    } else {
-        $current['model'] = array_key_first(AICP_AVAILABLE_MODELS);
+    $was_forwarding = !empty($current['forward_to_webhook']) && !empty($current['forward_webhook_url']);
+    $new_forward_flag = !empty($s['forward_to_webhook']) ? 1 : 0;
+    $new_forward_url = isset($s['forward_webhook_url']) ? esc_url_raw($s['forward_webhook_url']) : '';
+    $new_forward_secret = isset($s['forward_webhook_secret']) ? sanitize_text_field($s['forward_webhook_secret']) : '';
+    $timeout_value = isset($s['forward_webhook_timeout']) ? intval($s['forward_webhook_timeout']) : 15;
+    $new_forward_timeout = max(5, min(120, $timeout_value));
+    $will_forward = $new_forward_flag && !empty($new_forward_url);
+    $lock_sections = $was_forwarding && $will_forward;
+
+    $current['forward_to_webhook'] = $new_forward_flag;
+    $current['forward_webhook_url'] = $new_forward_url;
+    $current['forward_webhook_secret'] = $new_forward_secret;
+    $current['forward_webhook_timeout'] = $new_forward_timeout;
+
+    if (!$lock_sections) {
+        // Instrucciones
+        if (isset($s['model'])) {
+            $model = sanitize_text_field($s['model']);
+            $current['model'] = array_key_exists($model, AICP_AVAILABLE_MODELS) ? $model : array_key_first(AICP_AVAILABLE_MODELS);
+        } else {
+            $current['model'] = array_key_first(AICP_AVAILABLE_MODELS);
+        }
+        $current['persona'] = isset($s['persona']) ? sanitize_textarea_field($s['persona']) : '';
+        $current['objective'] = isset($s['objective']) ? sanitize_textarea_field($s['objective']) : '';
+        $current['length_tone'] = isset($s['length_tone']) ? sanitize_textarea_field($s['length_tone']) : '';
+        $current['example'] = isset($s['example']) ? sanitize_textarea_field($s['example']) : '';
+        $current['template_id'] = isset($s['template_id']) ? sanitize_text_field($s['template_id']) : '';
+
+        if (isset($s['quick_replies']) && is_array($s['quick_replies'])) {
+            $current['quick_replies'] = array_map('sanitize_text_field', $s['quick_replies']);
+        }
+
+        if (!empty($s['use_custom_prompt']) && isset($s['custom_prompt'])) {
+            $current['custom_prompt'] = sanitize_textarea_field($s['custom_prompt']);
+        } else {
+            unset($current['custom_prompt']);
+        }
+
+        $current['compiled_prompt'] = sanitize_textarea_field(aicp_compile_prompt($current));
+
+        // Ajustes de captura de leads
+        $current['lead_auto_collect'] = !empty($s['lead_auto_collect']) ? 1 : 0;
+        $current['lead_email']        = isset($s['lead_email']) ? sanitize_email($s['lead_email']) : '';
+        $current['webhook_url']       = isset($s['webhook_url']) ? esc_url_raw($s['webhook_url']) : '';
+        $current['calendar_url']      = isset($s['calendar_url']) ? esc_url_raw($s['calendar_url']) : '';
+
+        // Guardar los nuevos campos de lead dinámicos
+        $current['lead_fields'] = [];
+        if (isset($s['lead_fields']) && is_array($s['lead_fields'])) {
+            foreach ($s['lead_fields'] as $field) {
+                if (!empty($field['name'])) {
+                    $current['lead_fields'][sanitize_key($field['name'])] = [
+                        'label' => sanitize_text_field($field['label'] ?? ''),
+                        'name' => sanitize_key($field['name']),
+                        'type' => sanitize_key($field['type'] ?? 'text'),
+                        'required' => isset($field['required']) ? 1 : 0,
+                    ];
+                }
+            }
+        }
     }
-    $current['persona'] = isset($s['persona']) ? sanitize_textarea_field($s['persona']) : '';
-    $current['objective'] = isset($s['objective']) ? sanitize_textarea_field($s['objective']) : '';
-    $current['length_tone'] = isset($s['length_tone']) ? sanitize_textarea_field($s['length_tone']) : '';
-    $current['example'] = isset($s['example']) ? sanitize_textarea_field($s['example']) : '';
-    $current['template_id'] = isset($s['template_id']) ? sanitize_text_field($s['template_id']) : '';
-
-    if (isset($s['quick_replies']) && is_array($s['quick_replies'])) {
-        $current['quick_replies'] = array_map('sanitize_text_field', $s['quick_replies']);
-
-    }
-
-    if (!empty($s['use_custom_prompt']) && isset($s['custom_prompt'])) {
-        $current['custom_prompt'] = sanitize_textarea_field($s['custom_prompt']);
-    } else {
-        unset($current['custom_prompt']);
-    }
-
-    $current['compiled_prompt'] = sanitize_textarea_field(aicp_compile_prompt($current));
 
     // Diseño
     $current['bot_avatar_url'] = isset($s['bot_avatar_url']) ? esc_url_raw($s['bot_avatar_url']) : '';
@@ -493,34 +545,6 @@ function aicp_save_meta_box_data($post_id) {
     $current['color_bot_text'] = isset($s['color_bot_text']) ? sanitize_hex_color($s['color_bot_text']) : '#333333';
     $current['color_user_bg'] = isset($s['color_user_bg']) ? sanitize_hex_color($s['color_user_bg']) : '#dcf8c6';
     $current['color_user_text'] = isset($s['color_user_text']) ? sanitize_hex_color($s['color_user_text']) : '#000000';
-
-    // Ajustes de captura de leads
-    $current['lead_auto_collect'] = !empty($s['lead_auto_collect']) ? 1 : 0;
-    $current['lead_email']        = isset($s['lead_email']) ? sanitize_email($s['lead_email']) : '';
-    $current['webhook_url']       = isset($s['webhook_url']) ? esc_url_raw($s['webhook_url']) : '';
-    $current['calendar_url']      = isset($s['calendar_url']) ? esc_url_raw($s['calendar_url']) : '';
-
-    // Integraciones
-    $current['forward_to_webhook']      = !empty($s['forward_to_webhook']) ? 1 : 0;
-    $current['forward_webhook_url']     = isset($s['forward_webhook_url']) ? esc_url_raw($s['forward_webhook_url']) : '';
-    $current['forward_webhook_secret']  = isset($s['forward_webhook_secret']) ? sanitize_text_field($s['forward_webhook_secret']) : '';
-    $timeout_value                      = isset($s['forward_webhook_timeout']) ? intval($s['forward_webhook_timeout']) : 15;
-    $current['forward_webhook_timeout'] = max(5, min(120, $timeout_value));
-
-    // Guardar los nuevos campos de lead dinámicos
-    $current['lead_fields'] = [];
-    if (isset($s['lead_fields']) && is_array($s['lead_fields'])) {
-        foreach ($s['lead_fields'] as $field) {
-            if (!empty($field['name'])) {
-                $current['lead_fields'][sanitize_key($field['name'])] = [
-                    'label' => sanitize_text_field($field['label'] ?? ''),
-                    'name' => sanitize_key($field['name']),
-                    'type' => sanitize_key($field['type'] ?? 'text'),
-                    'required' => isset($field['required']) ? 1 : 0,
-                ];
-            }
-        }
-    }
 
     // Se elimina el guardado de los mensajes de cierre que ya no existen
     unset($current['lead_action_messages']);

--- a/ai-chatbot-pro/assets/css/admin.css
+++ b/ai-chatbot-pro/assets/css/admin.css
@@ -112,6 +112,41 @@
 }
 .aicp-instructions-fields.aicp-instructions-locked table { filter: grayscale(0.6); }
 
+/* Bloqueo de leads y pestañas PRO cuando se usa el webhook */
+.aicp-lead-settings { position: relative; }
+#aicp-tab-leads.aicp-leads-tab--locked .aicp-lead-settings::after,
+.aicp-lead-settings.aicp-lead-settings--locked::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(255, 255, 255, 0.6);
+    pointer-events: auto;
+    cursor: not-allowed;
+    z-index: 1;
+}
+#aicp-tab-leads.aicp-leads-tab--locked .aicp-lead-settings table {
+    filter: grayscale(0.6);
+}
+
+#aicp-tab-pro.aicp-pro-tab--locked,
+#aicp-tab-pro-upsell.aicp-pro-tab--locked {
+    position: relative;
+}
+#aicp-tab-pro.aicp-pro-tab--locked::after,
+#aicp-tab-pro-upsell.aicp-pro-tab--locked::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(255, 255, 255, 0.6);
+    pointer-events: auto;
+    cursor: not-allowed;
+    z-index: 1;
+}
+#aicp-tab-pro.aicp-pro-tab--locked .aicp-pro-training-fields,
+#aicp-tab-pro-upsell.aicp-pro-tab--locked .aicp-pro-feature-wrapper {
+    filter: grayscale(0.6);
+}
+
 /* Página de analíticas */
 #aicp-analytics-page .aicp-stats-boxes { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 20px; margin-top: 20px; }
 #aicp-analytics-page .aicp-stat-box { background: #fff; padding: 20px; border: 1px solid #e5e5e5; box-shadow: 0 1px 1px rgba(0,0,0,.04); }

--- a/ai-chatbot-pro/assets/js/admin-scripts.js
+++ b/ai-chatbot-pro/assets/js/admin-scripts.js
@@ -327,6 +327,305 @@ jQuery(function($) {
         }
     }
 
+    function handleLeadsLock() {
+        const $tab = $('#aicp-tab-leads');
+        if (!$tab.length) {
+            return;
+        }
+
+        const $toggle = $('#aicp_forward_to_webhook');
+        const $notice = $tab.find('.aicp-leads-lock-notice');
+        const $fieldset = $tab.find('.aicp-lead-settings');
+
+        function getLockableFields() {
+            return $tab.find('input[name^="aicp_settings"], textarea[name^="aicp_settings"], select[name^="aicp_settings"]').filter(function() {
+                const $el = $(this);
+                if ($el.hasClass('aicp-lock-hidden')) {
+                    return false;
+                }
+                const type = ($el.attr('type') || '').toLowerCase();
+                return type !== 'hidden';
+            });
+        }
+
+        function createHiddenMirror($el) {
+            const name = $el.attr('name');
+            if (!name) {
+                return null;
+            }
+
+            let $hidden = $el.data('aicpLockHidden');
+            if (!$hidden || !$hidden.length) {
+                $hidden = $('<input type="hidden" class="aicp-lock-hidden" />').attr('name', name);
+                $el.after($hidden);
+                $el.data('aicpLockHidden', $hidden);
+            }
+
+            if ($el.is(':checkbox') || $el.is(':radio')) {
+                $hidden.val($el.is(':checked') ? ($el.val() || 'on') : '');
+            } else if ($el.is('select')) {
+                const value = $el.val();
+                if (Array.isArray(value)) {
+                    $hidden.val(value.join(','));
+                } else {
+                    $hidden.val(value);
+                }
+            }
+
+            return $hidden;
+        }
+
+        function removeHiddenMirror($el) {
+            const $hidden = $el.data('aicpLockHidden');
+            if ($hidden && $hidden.length) {
+                $hidden.remove();
+                $el.removeData('aicpLockHidden');
+            }
+        }
+
+        function lockElement($el) {
+            const type = ($el.attr('type') || '').toLowerCase();
+
+            if ($el.is('textarea') || ($el.is('input') && !['checkbox', 'radio', 'button', 'submit', 'file'].includes(type))) {
+                if (typeof $el.data('aicpOriginalReadonly') === 'undefined') {
+                    $el.data('aicpOriginalReadonly', $el.prop('readonly'));
+                }
+                $el.prop('readonly', true);
+            }
+
+            if ($el.is('select') || $el.is(':checkbox') || $el.is(':radio')) {
+                if (typeof $el.data('aicpOriginalDisabled') === 'undefined') {
+                    $el.data('aicpOriginalDisabled', $el.prop('disabled'));
+                }
+                $el.prop('disabled', true);
+                createHiddenMirror($el);
+            }
+        }
+
+        function unlockElement($el) {
+            const type = ($el.attr('type') || '').toLowerCase();
+
+            if ($el.is('textarea') || ($el.is('input') && !['checkbox', 'radio', 'button', 'submit', 'file'].includes(type))) {
+                if (typeof $el.data('aicpOriginalReadonly') !== 'undefined') {
+                    $el.prop('readonly', $el.data('aicpOriginalReadonly'));
+                } else {
+                    $el.prop('readonly', false);
+                }
+            }
+
+            if ($el.is('select') || $el.is(':checkbox') || $el.is(':radio')) {
+                if (typeof $el.data('aicpOriginalDisabled') !== 'undefined') {
+                    $el.prop('disabled', $el.data('aicpOriginalDisabled'));
+                } else {
+                    $el.prop('disabled', false);
+                }
+                removeHiddenMirror($el);
+            }
+        }
+
+        function toggleActionButtons(locked) {
+            $tab.find('.aicp-add-lead-field, .aicp-remove-lead-field').each(function() {
+                const $btn = $(this);
+                if (locked) {
+                    if (typeof $btn.data('aicpOriginalDisabled') === 'undefined') {
+                        $btn.data('aicpOriginalDisabled', $btn.prop('disabled'));
+                    }
+                    $btn.prop('disabled', true).attr('aria-disabled', 'true');
+                } else {
+                    if (typeof $btn.data('aicpOriginalDisabled') !== 'undefined') {
+                        $btn.prop('disabled', $btn.data('aicpOriginalDisabled'));
+                    } else {
+                        $btn.prop('disabled', false);
+                    }
+                    $btn.removeAttr('aria-disabled');
+                }
+            });
+        }
+
+        function setLocked(locked) {
+            if (locked) {
+                $tab.addClass('aicp-leads-tab--locked');
+                $fieldset.addClass('aicp-lead-settings--locked');
+                $notice.show();
+            } else {
+                $tab.removeClass('aicp-leads-tab--locked');
+                $fieldset.removeClass('aicp-lead-settings--locked');
+                $notice.hide();
+            }
+
+            const $fields = getLockableFields();
+            $fields.each(function() {
+                const $field = $(this);
+                if (locked) {
+                    lockElement($field);
+                } else {
+                    unlockElement($field);
+                }
+            });
+
+            toggleActionButtons(locked);
+        }
+
+        const initialLocked = $tab.data('forwardingActive') === 1 || ($toggle.length && ($toggle.is(':checked') || !!(aicp_admin_params.initial_settings && aicp_admin_params.initial_settings.forward_to_webhook)));
+        setLocked(initialLocked);
+
+        if ($toggle.length) {
+            $toggle.on('change', function() {
+                setLocked($toggle.is(':checked'));
+            });
+        }
+    }
+
+    function handleProTabLock() {
+        const $tabs = $('#aicp-tab-pro, #aicp-tab-pro-upsell');
+        if (!$tabs.length) {
+            return;
+        }
+
+        const $toggle = $('#aicp_forward_to_webhook');
+
+        function getLockableFields($scope) {
+            return $scope.find('input, textarea, select').filter(function() {
+                const $el = $(this);
+                if ($el.hasClass('aicp-lock-hidden')) {
+                    return false;
+                }
+                const type = ($el.attr('type') || '').toLowerCase();
+                return type !== 'hidden';
+            });
+        }
+
+        function createHiddenMirror($el) {
+            const name = $el.attr('name');
+            if (!name) {
+                return null;
+            }
+
+            let $hidden = $el.data('aicpLockHidden');
+            if (!$hidden || !$hidden.length) {
+                $hidden = $('<input type="hidden" class="aicp-lock-hidden" />').attr('name', name);
+                $el.after($hidden);
+                $el.data('aicpLockHidden', $hidden);
+            }
+
+            if ($el.is(':checkbox') || $el.is(':radio')) {
+                $hidden.val($el.is(':checked') ? ($el.val() || 'on') : '');
+            } else if ($el.is('select')) {
+                const value = $el.val();
+                if (Array.isArray(value)) {
+                    $hidden.val(value.join(','));
+                } else {
+                    $hidden.val(value);
+                }
+            }
+
+            return $hidden;
+        }
+
+        function removeHiddenMirror($el) {
+            const $hidden = $el.data('aicpLockHidden');
+            if ($hidden && $hidden.length) {
+                $hidden.remove();
+                $el.removeData('aicpLockHidden');
+            }
+        }
+
+        function lockElement($el) {
+            const type = ($el.attr('type') || '').toLowerCase();
+
+            if ($el.is('textarea') || ($el.is('input') && !['checkbox', 'radio', 'button', 'submit', 'file'].includes(type))) {
+                if (typeof $el.data('aicpOriginalReadonly') === 'undefined') {
+                    $el.data('aicpOriginalReadonly', $el.prop('readonly'));
+                }
+                $el.prop('readonly', true);
+            }
+
+            if ($el.is('select') || $el.is(':checkbox') || $el.is(':radio')) {
+                if (typeof $el.data('aicpOriginalDisabled') === 'undefined') {
+                    $el.data('aicpOriginalDisabled', $el.prop('disabled'));
+                }
+                $el.prop('disabled', true);
+                createHiddenMirror($el);
+            }
+        }
+
+        function unlockElement($el) {
+            const type = ($el.attr('type') || '').toLowerCase();
+
+            if ($el.is('textarea') || ($el.is('input') && !['checkbox', 'radio', 'button', 'submit', 'file'].includes(type))) {
+                if (typeof $el.data('aicpOriginalReadonly') !== 'undefined') {
+                    $el.prop('readonly', $el.data('aicpOriginalReadonly'));
+                } else {
+                    $el.prop('readonly', false);
+                }
+            }
+
+            if ($el.is('select') || $el.is(':checkbox') || $el.is(':radio')) {
+                if (typeof $el.data('aicpOriginalDisabled') !== 'undefined') {
+                    $el.prop('disabled', $el.data('aicpOriginalDisabled'));
+                } else {
+                    $el.prop('disabled', false);
+                }
+                removeHiddenMirror($el);
+            }
+        }
+
+        function toggleActionButtons($scope, locked) {
+            $scope.find('.aicp-pro-training-fields button, .aicp-pro-training-fields .button').each(function() {
+                const $btn = $(this);
+                if (locked) {
+                    if (typeof $btn.data('aicpOriginalDisabled') === 'undefined') {
+                        $btn.data('aicpOriginalDisabled', $btn.prop('disabled'));
+                    }
+                    $btn.prop('disabled', true).attr('aria-disabled', 'true');
+                } else {
+                    if (typeof $btn.data('aicpOriginalDisabled') !== 'undefined') {
+                        $btn.prop('disabled', $btn.data('aicpOriginalDisabled'));
+                    } else {
+                        $btn.prop('disabled', false);
+                    }
+                    $btn.removeAttr('aria-disabled');
+                }
+            });
+        }
+
+        function setLocked(locked) {
+            $tabs.each(function() {
+                const $tab = $(this);
+                const $notice = $tab.find('.aicp-pro-lock-notice');
+
+                if (locked) {
+                    $tab.addClass('aicp-pro-tab--locked');
+                    $notice.show();
+                } else {
+                    $tab.removeClass('aicp-pro-tab--locked');
+                    $notice.hide();
+                }
+
+                const $fields = getLockableFields($tab);
+                $fields.each(function() {
+                    const $field = $(this);
+                    if (locked) {
+                        lockElement($field);
+                    } else {
+                        unlockElement($field);
+                    }
+                });
+
+                toggleActionButtons($tab, locked);
+            });
+        }
+
+        const initialLocked = $tabs.first().data('forwardingActive') === 1 || ($toggle.length && ($toggle.is(':checked') || !!(aicp_admin_params.initial_settings && aicp_admin_params.initial_settings.forward_to_webhook)));
+        setLocked(initialLocked);
+
+        if ($toggle.length) {
+            $toggle.on('change', function() {
+                setLocked($toggle.is(':checked'));
+            });
+        }
+    }
+
     function handleProTrainingLock() {
         const $container = $('.aicp-pro-training-fields');
         if (!$container.length) {
@@ -612,6 +911,8 @@ jQuery(function($) {
         initTemplateSelector();
         handleCustomPromptToggle();
         handleWebhookToggle();
+        handleLeadsLock();
+        handleProTabLock();
         handleProTrainingLock();
 
     }

--- a/ai-chatbot-pro/assets/js/chatbot.js
+++ b/ai-chatbot-pro/assets/js/chatbot.js
@@ -6,6 +6,14 @@ jQuery(function($) {
     const params = window.aicp_chatbot_params;
     if (!params) return;
     params.quick_replies = Array.isArray(params.quick_replies) ? params.quick_replies : [];
+    const forwardingActive = !!params.forwarding_active;
+
+    if (forwardingActive) {
+        params.quick_replies = [];
+        if (params.auto_open && typeof params.auto_open === 'object') {
+            params.auto_open.message = '';
+        }
+    }
 
     let conversationHistory = [];
     let logId = 0;

--- a/ai-chatbot-pro/includes/class-ajax-handler.php
+++ b/ai-chatbot-pro/includes/class-ajax-handler.php
@@ -203,15 +203,15 @@ class AICP_Ajax_Handler {
 
         $use_webhook = !empty($s['forward_to_webhook']) && !empty($s['forward_webhook_url']);
 
-        $system_prompt = '';
-        if (!$use_webhook) {
-            $system_prompt = AICP_Prompt_Builder::build($s, $page_context);
-        }
+        $system_prompt = AICP_Prompt_Builder::build($s, $page_context);
 
         $short_term_memory = array_slice($history, -10);
         $conversation = [];
-        if (!$use_webhook) {
-            $conversation[] = ['role' => 'system', 'content' => $system_prompt];
+        if ('' !== trim($system_prompt)) {
+            $conversation[] = [
+                'role'    => 'system',
+                'content' => $system_prompt,
+            ];
         }
         foreach ($short_term_memory as $item) {
             if (isset($item['role'], $item['content'])) {

--- a/ai-chatbot-pro/includes/class-frontend-loader.php
+++ b/ai-chatbot-pro/includes/class-frontend-loader.php
@@ -104,6 +104,7 @@ class AICP_Frontend_Loader {
         $auto_open_delay    = isset($s['auto_open_delay']) ? max(0, intval($s['auto_open_delay'])) : 0;
         $auto_open_duration = isset($s['auto_open_duration']) ? max(0, intval($s['auto_open_duration'])) : 0;
         $auto_open_message  = isset($s['auto_open_message']) ? sanitize_textarea_field($s['auto_open_message']) : '';
+        $forwarding_active  = !empty($s['forward_to_webhook']) && !empty($s['forward_webhook_url']);
 
         wp_localize_script('aicp-chatbot-script', 'aicp_chatbot_params', [
             'ajax_url' => admin_url('admin-ajax.php'),
@@ -119,6 +120,8 @@ class AICP_Frontend_Loader {
             'open_icon' => !empty($s['open_icon_url']) ? esc_url($s['open_icon_url']) : $default_open_icon,
 
             'quick_replies' => $quick_replies,
+
+            'forwarding_active' => $forwarding_active,
 
             'lead_auto_collect'  => $lead_auto_collect,
             'calendar_url'       => $calendar_url,

--- a/ai-chatbot-pro/includes/class-shortcode-handler.php
+++ b/ai-chatbot-pro/includes/class-shortcode-handler.php
@@ -84,6 +84,7 @@ class AICP_Shortcode_Handler {
         $auto_open_duration = isset($s['auto_open_duration']) ? max(0, intval($s['auto_open_duration'])) : 0;
         $auto_open_message  = isset($s['auto_open_message']) ? sanitize_textarea_field($s['auto_open_message']) : '';
         $lead_fields_config = AICP_Lead_Manager::get_lead_field_config($assistant_id, $s);
+        $forwarding_active  = !empty($s['forward_to_webhook']) && !empty($s['forward_webhook_url']);
 
         wp_localize_script('aicp-chatbot-script', 'aicp_chatbot_params', [
             'ajax_url'           => admin_url('admin-ajax.php'),
@@ -98,6 +99,8 @@ class AICP_Shortcode_Handler {
             'position'           => $s['position'] ?? 'br',
 
             'quick_replies' => $quick_replies,
+
+            'forwarding_active' => $forwarding_active,
 
             'lead_auto_collect'  => $lead_auto_collect,
             'calendar_url'       => $calendar_url,


### PR DESCRIPTION
## Summary
- always include the compiled system prompt when forwarding chat turns to an external webhook and expose the forwarding flag to the frontend
- hide default quick replies/auto messages when the webhook is active and surface the flag to the chatbot script
- lock assistant configuration, lead capture, and PRO controls in the admin UI (and ignore their payload on save) while webhook forwarding remains enabled

## Testing
- php -l ai-chatbot-pro/includes/class-ajax-handler.php
- php -l ai-chatbot-pro/includes/class-frontend-loader.php
- php -l ai-chatbot-pro/includes/class-shortcode-handler.php
- php -l ai-chatbot-pro/admin/assistant-meta-boxes.php

------
https://chatgpt.com/codex/tasks/task_e_68f23f8397a0833085028f009cf889d4