### PR TITLE
Improve chatbot session resilience

### DIFF
--- a/ai-chatbot-pro/ai-chatbot-pro.php
+++ b/ai-chatbot-pro/ai-chatbot-pro.php
@@ -154,6 +154,7 @@ final class AI_Chatbot_Pro {
 
         // Clases principales
         require_once AICP_PLUGIN_DIR . 'includes/template-functions.php';
+        require_once AICP_PLUGIN_DIR . 'includes/class-session-memory.php';
         require_once AICP_PLUGIN_DIR . 'includes/class-prompt-builder.php';
         require_once AICP_PLUGIN_DIR . 'includes/class-installer.php';
         require_once AICP_PLUGIN_DIR . 'includes/class-shortcode-handler.php';

--- a/ai-chatbot-pro/assets/js/chatbot.js
+++ b/ai-chatbot-pro/assets/js/chatbot.js
@@ -91,6 +91,14 @@ jQuery(function($) {
         inactivityTimer = setTimeout(finalizeChat, 45000);
     }
 
+    function resumeChatSession() {
+        if (!isChatEnded) return;
+        isChatEnded = false;
+        $('#aicp-chat-input').prop('disabled', false);
+        $('#aicp-send-button').prop('disabled', false);
+        resetInactivityTimer();
+    }
+
     function isFarewell(message) {
         if (!message) return false;
         return farewellPatterns.some(p => p.test(message.toLowerCase()));
@@ -573,7 +581,7 @@ function renderQuickReplies() {
                 session_id: sessionId
             },
             complete: () => {
-                // Resetear estado sin recargar
+                resumeChatSession();
             }
         });
     }
@@ -585,6 +593,10 @@ function renderQuickReplies() {
     }
 
     function sendMessage(message) {
+        if (isChatEnded) {
+            resumeChatSession();
+        }
+
         if (!message || isThinking || isChatEnded) return;
 
         resetInactivityTimer();

--- a/ai-chatbot-pro/includes/class-ajax-handler.php
+++ b/ai-chatbot-pro/includes/class-ajax-handler.php
@@ -79,6 +79,29 @@ class AICP_Ajax_Handler {
         return $session_id;
     }
 
+    private static function get_client_ip() {
+        $keys = [
+            'HTTP_CLIENT_IP',
+            'HTTP_X_FORWARDED_FOR',
+            'REMOTE_ADDR',
+        ];
+
+        foreach ($keys as $key) {
+            if (empty($_SERVER[$key])) {
+                continue;
+            }
+
+            $ip_list = explode(',', wp_unslash($_SERVER[$key]));
+            $candidate = trim($ip_list[0]);
+
+            if (filter_var($candidate, FILTER_VALIDATE_IP)) {
+                return $candidate;
+            }
+        }
+
+        return '0.0.0.0';
+    }
+
     private static function sanitize_lead_payload($lead_input) {
         $sanitized = [];
 
@@ -179,21 +202,32 @@ class AICP_Ajax_Handler {
 
         // --- INICIO DE LA MODIFICACIÓN ---
         $assistant_id = isset($_POST['assistant_id']) ? absint($_POST['assistant_id']) : 0;
+        if (empty($assistant_id)) {
+            wp_send_json_error(['message' => __('Datos inválidos.', 'ai-chatbot-pro')]);
+        }
+
         $history = isset($_POST['history']) && is_array($_POST['history']) ? wp_unslash($_POST['history']) : [];
         $log_id = isset($_POST['log_id']) ? absint($_POST['log_id']) : 0;
         // Se añade la recepción del contexto de la página
         $page_context = isset($_POST['page_context']) ? sanitize_textarea_field(wp_unslash($_POST['page_context'])) : '';
 
-        if (empty($assistant_id) || empty($history)) { 
-            wp_send_json_error(['message' => __('Datos inválidos.', 'ai-chatbot-pro')]); 
+        $incoming_session_id = isset($_POST['session_id']) ? wp_unslash($_POST['session_id']) : '';
+        $session_id = self::ensure_session_id($incoming_session_id);
+        $client_ip = self::get_client_ip();
+
+        if (!empty($history)) {
+            $history = AICP_Session_Memory::persist($session_id, $client_ip, $history, $assistant_id);
+        } else {
+            $history = AICP_Session_Memory::load($session_id, $client_ip, $assistant_id);
+        }
+
+        if (empty($assistant_id) || empty($history)) {
+            wp_send_json_error(['message' => __('Datos inválidos.', 'ai-chatbot-pro')]);
         }
 
         $global_settings = get_option('aicp_settings');
         $s = get_post_meta($assistant_id, '_aicp_assistant_settings', true);
         if (!is_array($s)) { $s = []; }
-
-        $incoming_session_id = isset($_POST['session_id']) ? wp_unslash($_POST['session_id']) : '';
-        $session_id = self::ensure_session_id($incoming_session_id);
 
         $lead_payload = [];
         if (isset($_POST['lead_data'])) {
@@ -205,7 +239,7 @@ class AICP_Ajax_Handler {
 
         $system_prompt = AICP_Prompt_Builder::build($s, $page_context);
 
-        $short_term_memory = array_slice($history, -10);
+        $short_term_memory = $history;
         $conversation = [];
         if ('' !== trim($system_prompt)) {
             $conversation[] = [
@@ -272,6 +306,8 @@ class AICP_Ajax_Handler {
         $full_history = $history;
         $full_history[] = ['role' => 'assistant', 'content' => $reply];
 
+        AICP_Session_Memory::persist($session_id, $client_ip, $full_history, $assistant_id);
+
         $lead_info = AICP_Lead_Manager::detect_contact_data($full_history, $assistant_id, $s);
 
         $lead_payload = $lead_info['is_complete'] ? $lead_info['data'] : [];
@@ -329,9 +365,21 @@ class AICP_Ajax_Handler {
         check_ajax_referer('aicp_chat_nonce', 'nonce');
 
         $assistant_id = isset($_POST['assistant_id']) ? absint($_POST['assistant_id']) : 0;
+        if (empty($assistant_id)) {
+            wp_send_json_error(['message' => __('Datos inválidos.', 'ai-chatbot-pro')]);
+        }
+
         $log_id       = isset($_POST['log_id']) ? absint($_POST['log_id']) : 0;
         $conversation = isset($_POST['conversation']) && is_array($_POST['conversation']) ? wp_unslash($_POST['conversation']) : [];
         $incoming_session_id = isset($_POST['session_id']) ? wp_unslash($_POST['session_id']) : '';
+        $session_id = self::ensure_session_id($incoming_session_id);
+        $client_ip = self::get_client_ip();
+
+        if (!empty($conversation)) {
+            $conversation = AICP_Session_Memory::persist($session_id, $client_ip, $conversation, $assistant_id);
+        } else {
+            $conversation = AICP_Session_Memory::load($session_id, $client_ip, $assistant_id);
+        }
 
         if (!$assistant_id || empty($conversation)) {
             wp_send_json_error(['message' => __('Datos inválidos.', 'ai-chatbot-pro')]);
@@ -392,7 +440,6 @@ class AICP_Ajax_Handler {
             }
         }
 
-        $session_id = self::ensure_session_id($incoming_session_id);
         $new_log_id = self::save_conversation($log_id, $assistant_id, $session_id, $conversation);
 
         global $wpdb;

--- a/ai-chatbot-pro/includes/class-session-memory.php
+++ b/ai-chatbot-pro/includes/class-session-memory.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * Gestiona la memoria de las sesiones del chatbot en una cola circular.
+ *
+ * @package AI_Chatbot_Pro
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!defined('HOUR_IN_SECONDS')) {
+    define('HOUR_IN_SECONDS', 3600);
+}
+
+class AICP_Session_Memory {
+    /** Número máximo de mensajes a mantener por sesión. */
+    public const MAX_MESSAGES = 15;
+
+    /** Prefijo utilizado para almacenar los transients. */
+    private const TRANSIENT_PREFIX = 'aicp_mem_';
+
+    /** Tiempo de expiración de la memoria (en segundos). */
+    private const EXPIRATION = 6 * HOUR_IN_SECONDS;
+
+    /** Almacenamiento alternativo usado en entornos de test sin WordPress. */
+    private static $fallback_store = [];
+
+    /**
+     * Obtiene y normaliza la conversación almacenada para una sesión.
+     */
+    public static function load($session_id, $ip = '', $assistant_id = 0) {
+        $key = self::build_key($session_id, $ip, $assistant_id);
+        $history = self::get_transient_value($key);
+
+        if (!is_array($history) || empty($history)) {
+            $history = self::load_from_logs($session_id, $assistant_id);
+            if (!empty($history)) {
+                self::set_transient_value($key, $history);
+            }
+        }
+
+        return self::normalize_history($history);
+    }
+
+    /**
+     * Guarda una conversación completa sobrescribiendo la cola circular.
+     */
+    public static function persist($session_id, $ip, array $conversation, $assistant_id = 0) {
+        $normalized = self::normalize_history($conversation);
+        $key = self::build_key($session_id, $ip, $assistant_id);
+        self::set_transient_value($key, $normalized);
+        return $normalized;
+    }
+
+    /**
+     * Añade mensajes a la conversación manteniendo el límite de la cola circular.
+     */
+    public static function append($session_id, $ip, array $messages, $assistant_id = 0) {
+        $current = self::load($session_id, $ip, $assistant_id);
+        $merged = array_merge($current, self::normalize_history($messages));
+        return self::persist($session_id, $ip, $merged, $assistant_id);
+    }
+
+    /**
+     * Elimina la memoria almacenada para una sesión concreta.
+     */
+    public static function forget($session_id, $ip = '', $assistant_id = 0) {
+        $key = self::build_key($session_id, $ip, $assistant_id);
+        self::delete_transient_value($key);
+    }
+
+    /**
+     * Construye una clave segura basada en la sesión, IP y asistente.
+     */
+    private static function build_key($session_id, $ip, $assistant_id) {
+        $session = is_string($session_id) ? trim($session_id) : '';
+        $ip_hash = is_string($ip) ? trim($ip) : '';
+        $assistant = self::absint($assistant_id);
+
+        if ('' === $session && '' === $ip_hash) {
+            $ip_hash = 'guest';
+        }
+
+        $raw = $session . '|' . $ip_hash . '|' . $assistant;
+        return self::TRANSIENT_PREFIX . md5($raw);
+    }
+
+    /**
+     * Normaliza una conversación asegurando estructura y límite de elementos.
+     */
+    private static function normalize_history($conversation) {
+        if (!is_array($conversation)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($conversation as $message) {
+            if (!is_array($message)) {
+                continue;
+            }
+
+            $role = self::sanitize_role($message['role'] ?? '');
+            $content = self::sanitize_content($message['content'] ?? '');
+
+            if ('' === $content || '' === $role) {
+                continue;
+            }
+
+            $normalized[] = [
+                'role'    => $role,
+                'content' => $content,
+            ];
+        }
+
+        if (count($normalized) > self::MAX_MESSAGES) {
+            $normalized = array_slice($normalized, -self::MAX_MESSAGES);
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Intenta reconstruir la conversación desde la tabla de logs si es posible.
+     */
+    private static function load_from_logs($session_id, $assistant_id = 0) {
+        if (!is_string($session_id) || '' === trim($session_id)) {
+            return [];
+        }
+
+        global $wpdb;
+        if (!isset($wpdb) || !isset($wpdb->prefix)) {
+            return [];
+        }
+
+        $table = $wpdb->prefix . 'aicp_chat_logs';
+        $prepared = $wpdb->prepare(
+            "SELECT conversation_log FROM {$table} WHERE session_id = %s" .
+            ($assistant_id ? ' AND assistant_id = %d' : '') .
+            ' ORDER BY id DESC LIMIT 1',
+            $assistant_id ? [$session_id, $assistant_id] : [$session_id]
+        );
+
+        if (!$prepared) {
+            return [];
+        }
+
+        $row = $wpdb->get_var($prepared);
+        if (!$row) {
+            return [];
+        }
+
+        $data = json_decode($row, true);
+        if (!is_array($data)) {
+            return [];
+        }
+
+        return self::normalize_history($data);
+    }
+
+    /** Wrapper para obtener un transient. */
+    private static function get_transient_value($key) {
+        if (function_exists('get_transient')) {
+            $value = get_transient($key);
+            return is_array($value) ? $value : [];
+        }
+
+        return self::$fallback_store[$key] ?? [];
+    }
+
+    /** Wrapper para guardar un transient. */
+    private static function set_transient_value($key, array $value) {
+        if (function_exists('set_transient')) {
+            set_transient($key, $value, self::EXPIRATION);
+            return;
+        }
+
+        self::$fallback_store[$key] = $value;
+    }
+
+    /** Wrapper para eliminar un transient. */
+    private static function delete_transient_value($key) {
+        if (function_exists('delete_transient')) {
+            delete_transient($key);
+            return;
+        }
+
+        unset(self::$fallback_store[$key]);
+    }
+
+    /**
+     * Sanitiza el rol del mensaje.
+     */
+    private static function sanitize_role($role) {
+        $role = is_string($role) ? strtolower($role) : '';
+
+        if (function_exists('sanitize_key')) {
+            $role = sanitize_key($role);
+        } else {
+            $role = preg_replace('/[^a-z0-9_\-]/', '', $role);
+        }
+
+        $allowed = ['user', 'assistant', 'system'];
+        if (!in_array($role, $allowed, true)) {
+            return '';
+        }
+
+        return $role;
+    }
+
+    /**
+     * Sanitiza el contenido del mensaje.
+     */
+    private static function sanitize_content($content) {
+        if (!is_string($content)) {
+            return '';
+        }
+
+        if (function_exists('sanitize_textarea_field')) {
+            return sanitize_textarea_field($content);
+        }
+
+        return trim(strip_tags($content));
+    }
+
+    /**
+     * Alternativa a absint cuando WordPress no está disponible.
+     */
+    private static function absint($value) {
+        if (function_exists('absint')) {
+            return absint($value);
+        }
+
+        return abs((int) $value);
+    }
+}

--- a/tests/test-session-memory.php
+++ b/tests/test-session-memory.php
@@ -1,0 +1,88 @@
+<?php
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+if (!defined('AICP_PLUGIN_DIR')) {
+    define('AICP_PLUGIN_DIR', __DIR__ . '/../ai-chatbot-pro/');
+}
+
+if (!function_exists('sanitize_key')) {
+    function sanitize_key($key) {
+        $key = strtolower((string) $key);
+        return preg_replace('/[^a-z0-9_\-]/', '', $key);
+    }
+}
+
+if (!function_exists('sanitize_textarea_field')) {
+    function sanitize_textarea_field($value) {
+        return trim(strip_tags((string) $value));
+    }
+}
+
+require_once AICP_PLUGIN_DIR . 'includes/class-session-memory.php';
+
+$session = 'test-session';
+$ip = '127.0.0.1';
+$assistant_id = 7;
+
+$history = [];
+for ($i = 0; $i < 20; $i++) {
+    $history[] = [
+        'role'    => $i % 2 === 0 ? 'user' : 'assistant',
+        'content' => 'mensaje-' . $i,
+    ];
+}
+
+$stored = AICP_Session_Memory::persist($session, $ip, $history, $assistant_id);
+assert(count($stored) === AICP_Session_Memory::MAX_MESSAGES);
+assert($stored[0]['content'] === 'mensaje-5');
+
+$loaded = AICP_Session_Memory::load($session, $ip, $assistant_id);
+assert($loaded === $stored);
+
+$updated = AICP_Session_Memory::append($session, $ip, [['role' => 'assistant', 'content' => 'nuevo']], $assistant_id);
+assert(count($updated) === AICP_Session_Memory::MAX_MESSAGES);
+assert(end($updated)['content'] === 'nuevo');
+assert($updated[0]['content'] === 'mensaje-6');
+
+AICP_Session_Memory::forget($session, $ip, $assistant_id);
+
+class FakeWpdb {
+    public $prefix = 'wp_';
+    public $fixture = [];
+    public $prepare_calls = 0;
+    public $last_args = [];
+
+    public function prepare($query, $args) {
+        $this->prepare_calls++;
+        $this->last_args = $args;
+        return 'prepared-query';
+    }
+
+    public function get_var($query) {
+        if ('prepared-query' !== $query) {
+            return null;
+        }
+        return json_encode($this->fixture);
+    }
+}
+
+global $wpdb;
+$wpdb = new FakeWpdb();
+$wpdb->fixture = [
+    ['role' => 'system', 'content' => 'Config'],
+    ['role' => 'user', 'content' => 'Hola <strong>mundo</strong>'],
+    ['role' => 'assistant', 'content' => '¡Hola!']
+];
+
+$fallback = AICP_Session_Memory::load($session, $ip, $assistant_id);
+assert(count($fallback) === 3);
+assert($fallback[1]['content'] === 'Hola mundo');
+assert($wpdb->prepare_calls === 1);
+
+// La segunda llamada debe usar la memoria en caché, sin incrementar prepare_calls.
+$cached = AICP_Session_Memory::load($session, $ip, $assistant_id);
+assert($cached === $fallback);
+assert($wpdb->prepare_calls === 1);
+
+echo "Session memory tests passed\n";


### PR DESCRIPTION
## Summary
- add a session memory manager that keeps a 15 message circular buffer per session/IP with log fallbacks
- wire the memory queue into the chat request/finalization handlers and capture client identifiers safely
- allow the frontend widget to resume after inactivity instead of staying disabled
- add a standalone test that exercises the in-memory queue behaviour

## Testing
- php tests/test-session-memory.php
- php tests/test-prompt-builder.php

------
https://chatgpt.com/codex/tasks/task_e_68f50424da10833086720189ba9c2cc9