### PR TITLE
Add admin-managed assistant templates and dynamic loading

### DIFF
--- a/ai-chatbot-pro/admin/assistant-meta-boxes.php
+++ b/ai-chatbot-pro/admin/assistant-meta-boxes.php
@@ -106,7 +106,7 @@ function aicp_admin_scripts($hook) {
         'default_bot_avatar' => $default_bot_avatar,
         'default_user_avatar' => $default_user_avatar,
         'default_open_icon' => $default_open_icon,
-        'templates_url' => AICP_PLUGIN_URL . 'assistant_templates.json',
+        'templates_url' => add_query_arg('action', 'aicp_get_templates', admin_url('admin-ajax.php')),
         'lead_fields' => AICP_Lead_Manager::get_lead_field_config($post_id, $settings),
         'initial_settings' => [
             'bot_avatar_url' => $settings['bot_avatar_url'] ?? $default_bot_avatar,

--- a/ai-chatbot-pro/admin/settings-page.php
+++ b/ai-chatbot-pro/admin/settings-page.php
@@ -27,8 +27,11 @@ add_action('admin_menu', 'aicp_add_settings_page');
  */
 function aicp_register_general_settings() {
     register_setting('aicp_settings_group', 'aicp_settings', 'aicp_general_settings_sanitize');
+    register_setting('aicp_settings_group', 'aicp_assistant_templates', 'aicp_assistant_templates_sanitize');
     add_settings_section('aicp_api_key_section', __('Ajustes de la API de OpenAI', 'ai-chatbot-pro'), null, 'aicp-settings');
     add_settings_field('aicp_api_key', __('API Key', 'ai-chatbot-pro'), 'aicp_api_key_field_render', 'aicp-settings', 'aicp_api_key_section');
+    add_settings_section('aicp_templates_section', __('Plantillas del asistente', 'ai-chatbot-pro'), 'aicp_templates_section_render', 'aicp-settings');
+    add_settings_field('aicp_template_editor', __('Plantillas disponibles', 'ai-chatbot-pro'), 'aicp_template_editor_field_render', 'aicp-settings', 'aicp_templates_section');
     do_action('aicp_after_settings_fields');
 }
 add_action('admin_init', 'aicp_register_general_settings');
@@ -63,13 +66,34 @@ function aicp_render_settings_page() {
         <form action="options.php" method="post">
             <?php settings_fields('aicp_settings_group'); ?>
             <?php do_settings_sections('aicp-settings'); ?>
-            <?php 
-        
-        do_action('aicp_after_settings_fields'); 
+            <?php
+
+        do_action('aicp_after_settings_fields');
         ?>
             <?php submit_button(); ?>
         </form>
     </div>
+    <?php
+}
+
+function aicp_templates_section_render() {
+    echo '<p>' . esc_html__('Edita las plantillas base que se utilizan al crear nuevos asistentes. Usa el formato JSON y asegúrate de mantener los identificadores únicos.', 'ai-chatbot-pro') . '</p>';
+}
+
+function aicp_template_editor_field_render() {
+    $stored_templates = get_option('aicp_assistant_templates');
+    if (!is_array($stored_templates) || empty($stored_templates)) {
+        if (function_exists('aicp_get_default_assistant_templates')) {
+            $stored_templates = aicp_get_default_assistant_templates();
+        } else {
+            $stored_templates = [];
+        }
+    }
+
+    $json = wp_json_encode($stored_templates, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+    ?>
+    <textarea name="aicp_assistant_templates" rows="15" class="large-text code" spellcheck="false"><?php echo esc_textarea($json); ?></textarea>
+    <p class="description"><?php esc_html_e('Introduce un array de objetos con los campos id, label y system_prompt_template. Los datos se sanitizan automáticamente antes de guardarse.', 'ai-chatbot-pro'); ?></p>
     <?php
 }
 
@@ -87,6 +111,41 @@ function aicp_general_settings_sanitize($input) {
     // Si el addon PRO está activo, le pasa los datos para que guarde los suyos.
     if (class_exists('AICP_Pro_Features')) {
         $sanitized = apply_filters('aicp_sanitize_pro_settings', $sanitized, $input);
+    }
+
+    return $sanitized;
+}
+
+function aicp_assistant_templates_sanitize($input) {
+    $raw = $input;
+
+    if (is_string($raw)) {
+        $raw = wp_unslash($raw);
+        $decoded = json_decode($raw, true);
+    } elseif (is_array($raw)) {
+        $decoded = $raw;
+    } else {
+        $decoded = [];
+    }
+
+    if (!is_array($decoded)) {
+        add_settings_error('aicp_assistant_templates', 'aicp_templates_invalid_json', __('El JSON proporcionado no es válido.', 'ai-chatbot-pro'));
+        return get_option('aicp_assistant_templates', []);
+    }
+
+    if (!function_exists('aicp_sanitize_assistant_templates_array')) {
+        require_once AICP_PLUGIN_DIR . 'includes/template-functions.php';
+    }
+
+    $sanitized = aicp_sanitize_assistant_templates_array($decoded);
+
+    if (empty($sanitized)) {
+        add_settings_error('aicp_assistant_templates', 'aicp_templates_empty', __('No se pudo guardar ninguna plantilla válida. Revisa el formato y los campos obligatorios.', 'ai-chatbot-pro'));
+        return get_option('aicp_assistant_templates', []);
+    }
+
+    if (function_exists('aicp_clear_assistant_templates_cache')) {
+        aicp_clear_assistant_templates_cache();
     }
 
     return $sanitized;

--- a/ai-chatbot-pro/includes/class-ajax-handler.php
+++ b/ai-chatbot-pro/includes/class-ajax-handler.php
@@ -19,6 +19,8 @@ class AICP_Ajax_Handler {
         add_action('wp_ajax_nopriv_aicp_submit_lead_form', [__CLASS__, 'handle_submit_lead_form']);
         add_action('wp_ajax_aicp_finalize_chat', [__CLASS__, 'handle_finalize_chat']);
         add_action('wp_ajax_nopriv_aicp_finalize_chat', [__CLASS__, 'handle_finalize_chat']);
+        add_action('wp_ajax_aicp_get_templates', [__CLASS__, 'handle_get_templates']);
+        add_action('wp_ajax_nopriv_aicp_get_templates', [__CLASS__, 'handle_get_templates']);
     }
     
     private static function save_conversation($log_id, $assistant_id, $session_id, $conversation, $lead_data = []) {
@@ -172,6 +174,15 @@ class AICP_Ajax_Handler {
         }
 
         return $result;
+    }
+
+    public static function handle_get_templates() {
+        if (!function_exists('aicp_get_assistant_templates')) {
+            require_once AICP_PLUGIN_DIR . 'includes/template-functions.php';
+        }
+
+        $templates = aicp_get_assistant_templates(false);
+        wp_send_json($templates);
     }
 
     public static function handle_chat_request() {

--- a/ai-chatbot-pro/includes/class-prompt-builder.php
+++ b/ai-chatbot-pro/includes/class-prompt-builder.php
@@ -6,12 +6,16 @@ class AICP_Prompt_Builder {
 
     private static function get_template($id) {
         if (self::$templates === null) {
-            $file = AICP_PLUGIN_DIR . 'assistant_templates.json';
-            if (file_exists($file)) {
-                $data = json_decode(file_get_contents($file), true);
-                self::$templates = is_array($data) ? $data : [];
+            if (function_exists('aicp_get_assistant_templates')) {
+                self::$templates = aicp_get_assistant_templates();
             } else {
-                self::$templates = [];
+                $file = AICP_PLUGIN_DIR . 'assistant_templates.json';
+                if (file_exists($file)) {
+                    $data = json_decode(file_get_contents($file), true);
+                    self::$templates = is_array($data) ? $data : [];
+                } else {
+                    self::$templates = [];
+                }
             }
         }
         foreach (self::$templates as $tpl) {

--- a/ai-chatbot-pro/includes/template-functions.php
+++ b/ai-chatbot-pro/includes/template-functions.php
@@ -17,3 +17,157 @@ if (!function_exists('aicp_render_template')) {
         }, $tpl);
     }
 }
+
+if (!function_exists('aicp_clear_assistant_templates_cache')) {
+    /**
+     * Removes the transient cache for assistant templates so the latest data is used.
+     */
+    function aicp_clear_assistant_templates_cache()
+    {
+        delete_transient('aicp_assistant_templates_cache');
+    }
+}
+
+if (!function_exists('aicp_normalize_assistant_template')) {
+    /**
+     * Normalizes and sanitizes the structure of an assistant template entry.
+     *
+     * @param array $template Raw template data.
+     *
+     * @return array|null Sanitized template or null if invalid.
+     */
+    function aicp_normalize_assistant_template($template)
+    {
+        if (!is_array($template)) {
+            return null;
+        }
+
+        $id = isset($template['id']) ? sanitize_key($template['id']) : '';
+        $label = isset($template['label']) ? sanitize_text_field($template['label']) : '';
+        $system_prompt = isset($template['system_prompt_template']) ? sanitize_textarea_field($template['system_prompt_template']) : '';
+
+        if ('' === $id || '' === $label || '' === $system_prompt) {
+            return null;
+        }
+
+        $normalized = [
+            'id'                     => $id,
+            'label'                  => $label,
+            'description'            => isset($template['description']) ? sanitize_text_field($template['description']) : '',
+            'variables'              => [],
+            'system_prompt_template' => $system_prompt,
+        ];
+
+        if (!empty($template['variables']) && is_array($template['variables'])) {
+            $normalized['variables'] = array_values(array_filter(array_map('sanitize_key', $template['variables'])));
+        }
+
+        $text_fields = ['persona', 'objective', 'length_tone', 'example'];
+        foreach ($text_fields as $field) {
+            if (isset($template[$field])) {
+                $normalized[$field] = sanitize_textarea_field($template[$field]);
+            }
+        }
+
+        if (!empty($template['quick_replies']) && is_array($template['quick_replies'])) {
+            $normalized['quick_replies'] = array_values(array_filter(array_map('sanitize_text_field', $template['quick_replies'])));
+        }
+
+        if (!empty($template['examples_by_intent']) && is_array($template['examples_by_intent'])) {
+            $examples = [];
+            foreach ($template['examples_by_intent'] as $key => $value) {
+                $normalized_key = sanitize_key($key);
+                if ($normalized_key === '') {
+                    continue;
+                }
+                $examples[$normalized_key] = sanitize_textarea_field($value);
+            }
+            if (!empty($examples)) {
+                $normalized['examples_by_intent'] = $examples;
+            }
+        }
+
+        return $normalized;
+    }
+}
+
+if (!function_exists('aicp_sanitize_assistant_templates_array')) {
+    /**
+     * Sanitizes an array of assistant templates.
+     *
+     * @param array $templates Raw templates array.
+     *
+     * @return array Sanitized array of templates.
+     */
+    function aicp_sanitize_assistant_templates_array($templates)
+    {
+        if (!is_array($templates)) {
+            return [];
+        }
+
+        $sanitized = [];
+        foreach ($templates as $template) {
+            $normalized = aicp_normalize_assistant_template($template);
+            if ($normalized) {
+                $sanitized[$normalized['id']] = $normalized;
+            }
+        }
+
+        return array_values($sanitized);
+    }
+}
+
+if (!function_exists('aicp_get_default_assistant_templates')) {
+    /**
+     * Loads the default assistant templates from the bundled JSON file.
+     *
+     * @return array
+     */
+    function aicp_get_default_assistant_templates()
+    {
+        $file = trailingslashit(AICP_PLUGIN_DIR) . 'assistant_templates.json';
+        if (!file_exists($file)) {
+            return [];
+        }
+
+        $data = json_decode(file_get_contents($file), true);
+        if (!is_array($data)) {
+            return [];
+        }
+
+        return aicp_sanitize_assistant_templates_array($data);
+    }
+}
+
+if (!function_exists('aicp_get_assistant_templates')) {
+    /**
+     * Retrieves the assistant templates, either from the stored option or the default file.
+     * Results are cached using transients for performance.
+     *
+     * @param bool $use_cache Whether to use the cached value.
+     *
+     * @return array
+     */
+    function aicp_get_assistant_templates($use_cache = true)
+    {
+        $cache_key = 'aicp_assistant_templates_cache';
+
+        if ($use_cache) {
+            $cached = get_transient($cache_key);
+            if ($cached !== false && is_array($cached)) {
+                return $cached;
+            }
+        }
+
+        $stored = get_option('aicp_assistant_templates');
+        if (is_array($stored) && !empty($stored)) {
+            $templates = aicp_sanitize_assistant_templates_array($stored);
+        } else {
+            $templates = aicp_get_default_assistant_templates();
+        }
+
+        set_transient($cache_key, $templates, DAY_IN_SECONDS);
+
+        return $templates;
+    }
+}

--- a/ai-chatbot-pro/templates/templates.js
+++ b/ai-chatbot-pro/templates/templates.js
@@ -1,9 +1,17 @@
 "use strict";
 var ASSISTANT_TEMPLATES = [];
 function loadAssistantTemplates(url) {
-    return fetch(url)
-        .then(function (res) { return res.json(); })
+    return fetch(url, { credentials: 'same-origin' })
+        .then(function (res) {
+        if (!res.ok) {
+            throw new Error('Failed to load assistant templates.');
+        }
+        return res.json();
+    })
         .then(function (data) {
+        if (!Array.isArray(data)) {
+            return [];
+        }
         ASSISTANT_TEMPLATES = data;
         window.ASSISTANT_TEMPLATES = ASSISTANT_TEMPLATES;
         return ASSISTANT_TEMPLATES;

--- a/ai-chatbot-pro/templates/templates.ts
+++ b/ai-chatbot-pro/templates/templates.ts
@@ -15,9 +15,17 @@ interface AssistantTemplate {
 let ASSISTANT_TEMPLATES: AssistantTemplate[] = [];
 
 function loadAssistantTemplates(url: string): Promise<AssistantTemplate[]> {
-  return fetch(url)
-    .then(res => res.json())
+  return fetch(url, { credentials: 'same-origin' })
+    .then(res => {
+      if (!res.ok) {
+        throw new Error('Failed to load assistant templates.');
+      }
+      return res.json();
+    })
     .then((data: AssistantTemplate[]) => {
+      if (!Array.isArray(data)) {
+        return [];
+      }
       ASSISTANT_TEMPLATES = data;
       (window as any).ASSISTANT_TEMPLATES = ASSISTANT_TEMPLATES;
       return ASSISTANT_TEMPLATES;


### PR DESCRIPTION
## Summary
- persist assistant templates in a WordPress option with sanitization, caching, and fallback to bundled defaults
- add a JSON-based editor on the settings page so administrators can manage template content safely
- expose an AJAX endpoint and update prompt loading to fetch templates dynamically in both PHP and JavaScript

## Testing
- php -l ai-chatbot-pro/includes/template-functions.php
- php -l ai-chatbot-pro/includes/class-prompt-builder.php
- php -l ai-chatbot-pro/admin/settings-page.php
- php -l ai-chatbot-pro/admin/assistant-meta-boxes.php
- php -l ai-chatbot-pro/includes/class-ajax-handler.php

------
https://chatgpt.com/codex/tasks/task_e_68f504292bdc8330a1b8233faddadb60