### PR TITLE
Lock assistant tabs when webhook integration is active

### DIFF
--- a/ai-chatbot-pro/admin/assistant-meta-boxes.php
+++ b/ai-chatbot-pro/admin/assistant-meta-boxes.php
@@ -12,17 +12,25 @@ if (!defined('ABSPATH')) exit;
 function aicp_add_meta_boxes() {
     add_action('edit_form_top', function($post) {
         if ($post->post_type !== 'aicp_assistant') return;
+
+        $settings = get_post_meta($post->ID, '_aicp_assistant_settings', true);
+        $settings = is_array($settings) ? $settings : [];
+        $forwarding_active = !empty($settings['forward_to_webhook']) && !empty($settings['forward_webhook_url']);
+
+        $disabled_class = $forwarding_active ? ' aicp-nav-tab--disabled' : '';
+        $disabled_attr  = $forwarding_active ? ' aria-disabled="true" data-tab-disabled="1"' : '';
+
         echo '<h2 class="nav-tab-wrapper aicp-nav-tab-wrapper">';
-        echo '<a href="#aicp-tab-instructions" class="nav-tab nav-tab-active">' . __('Instrucciones', 'ai-chatbot-pro') . '</a>';
+        echo '<a href="#aicp-tab-instructions" class="nav-tab nav-tab-active' . $disabled_class . '" data-lockable-tab="1"' . $disabled_attr . '>' . __('Instrucciones', 'ai-chatbot-pro') . '</a>';
         echo '<a href="#aicp-tab-design" class="nav-tab">' . __('Diseño', 'ai-chatbot-pro') . '</a>';
-        echo '<a href="#aicp-tab-leads" class="nav-tab">' . __('Leads', 'ai-chatbot-pro') . '</a>';
+        echo '<a href="#aicp-tab-leads" class="nav-tab' . $disabled_class . '" data-lockable-tab="1"' . $disabled_attr . '>' . __('Leads', 'ai-chatbot-pro') . '</a>';
         echo '<a href="#aicp-tab-integrations" class="nav-tab">' . __('Integraciones', 'ai-chatbot-pro') . '</a>';
-        
+
         // Lógica corregida para mostrar la pestaña PRO o el mensaje de venta.
         if (class_exists('AICP_Pro_Features')) {
-            echo '<a href="#aicp-tab-pro" class="nav-tab">' . __('Funciones PRO', 'ai-chatbot-pro') . ' <span class="aicp-pro-tag">PRO</span></a>';
+            echo '<a href="#aicp-tab-pro" class="nav-tab' . $disabled_class . '" data-lockable-tab="1"' . $disabled_attr . '>' . __('Funciones PRO', 'ai-chatbot-pro') . ' <span class="aicp-pro-tag">PRO</span></a>';
         } else {
-             echo '<a href="#aicp-tab-pro-upsell" class="nav-tab">' . __('Funciones PRO', 'ai-chatbot-pro') . ' <span class="aicp-pro-tag">PRO</span></a>';
+             echo '<a href="#aicp-tab-pro-upsell" class="nav-tab' . $disabled_class . '" data-lockable-tab="1"' . $disabled_attr . '>' . __('Funciones PRO', 'ai-chatbot-pro') . ' <span class="aicp-pro-tag">PRO</span></a>';
         }
         echo '</h2>';
     });
@@ -128,6 +136,7 @@ function aicp_admin_scripts($hook) {
         ],
         'meta' => $meta,
         'webhook_warning' => __('Si activas el reenvío al webhook externo, el asistente ignorará las instrucciones internas y no podrás editarlas hasta desactivar la integración. ¿Deseas continuar?', 'ai-chatbot-pro'),
+        'webhook_lock_message' => __('La integración con webhook está activa. Desactívala para volver a entrenar el asistente o modificar estas opciones PRO.', 'ai-chatbot-pro'),
     ]);
 }
 add_action('admin_enqueue_scripts', 'aicp_admin_scripts');
@@ -174,7 +183,7 @@ function aicp_render_main_meta_box($post) {
     if (class_exists('AICP_Pro_Features')) : ?>
         <div id="aicp-tab-pro" class="<?php echo esc_attr($pro_tab_classes); ?>" style="display:none;" data-forwarding-active="<?php echo $forwarding_active ? '1' : '0'; ?>">
             <div class="notice notice-warning inline aicp-pro-lock-notice"<?php echo $forwarding_active ? '' : ' style="display:none;"'; ?>>
-                <p><?php _e('Las funciones PRO están bloqueadas porque el asistente está reenviando los mensajes a un webhook externo. Desactiva la integración para realizar cambios.', 'ai-chatbot-pro'); ?></p>
+                <p><?php _e('La integración con webhook está activa. Desactívala para volver a entrenar el asistente o modificar estas opciones PRO.', 'ai-chatbot-pro'); ?></p>
             </div>
             <?php
             do_action('aicp_pro_tab_content');
@@ -196,7 +205,7 @@ function aicp_render_instructions_tab($v) {
     $is_forwarding_enabled = !empty($v['forward_to_webhook']);
     ?>
     <div class="notice notice-warning inline aicp-instructions-lock-notice"<?php echo $is_forwarding_enabled ? '' : ' style="display:none;"'; ?>>
-        <p><?php _e('Las instrucciones están desactivadas porque el asistente reenvía los mensajes a un webhook externo. Desactiva la integración para volver a editarlas.', 'ai-chatbot-pro'); ?></p>
+        <p><?php _e('La integración con webhook está activa. Desactívala para volver a entrenar el asistente o modificar estas opciones PRO.', 'ai-chatbot-pro'); ?></p>
     </div>
     <div class="aicp-instructions-fields<?php echo $is_forwarding_enabled ? ' aicp-instructions-locked' : ''; ?>">
         <table class="form-table">
@@ -327,7 +336,7 @@ function aicp_render_leads_tab($assistant_id, $v) {
     echo '<h4>' . __('Ajustes de Captura de Leads', 'ai-chatbot-pro') . '</h4>';
 
     $notice_style = $integration_active ? '' : ' style="display:none;"';
-    echo '<div class="notice notice-warning inline aicp-leads-lock-notice"' . $notice_style . '><p>' . __('Las opciones de leads están bloqueadas porque el asistente está reenviando los mensajes a un webhook externo. Desactiva la integración para modificar estos ajustes.', 'ai-chatbot-pro') . '</p></div>';
+    echo '<div class="notice notice-warning inline aicp-leads-lock-notice"' . $notice_style . '><p>' . __('La integración con webhook está activa. Desactívala para volver a entrenar el asistente o modificar estas opciones PRO.', 'ai-chatbot-pro') . '</p></div>';
 
     $fieldset_classes = 'aicp-lead-settings';
     if ($integration_active) {

--- a/ai-chatbot-pro/assets/css/admin.css
+++ b/ai-chatbot-pro/assets/css/admin.css
@@ -10,6 +10,20 @@
     font-size: 9px; font-weight: bold; padding: 2px 6px;
     border-radius: 3px; margin-left: 5px; vertical-align: middle;
 }
+.aicp-nav-tab-wrapper .aicp-nav-tab--disabled {
+    color: #a0a5aa;
+    border-color: #dcdcde;
+    background: #f6f7f7;
+    cursor: not-allowed;
+}
+.aicp-nav-tab-wrapper .aicp-nav-tab--disabled:hover,
+.aicp-nav-tab-wrapper .aicp-nav-tab--disabled:focus {
+    color: #a0a5aa;
+    box-shadow: none;
+}
+.aicp-nav-tab-wrapper .aicp-nav-tab--disabled.nav-tab-active {
+    border-bottom-color: #dcdcde;
+}
 .aicp-pro-feature-wrapper { background-color: #fff; border: 1px solid #ddd; padding: 20px; text-align: center; }
 
 /* Layout de Diseño y Previsualización */

--- a/ai-chatbot-pro/assets/js/admin-scripts.js
+++ b/ai-chatbot-pro/assets/js/admin-scripts.js
@@ -7,6 +7,25 @@ jQuery(function($) {
 
     const leadFieldDefinitions = aicp_admin_params.lead_fields || {};
     const escapeHtml = (text) => $('<div/>').text(text == null ? '' : String(text)).html();
+    const navLockMessage = aicp_admin_params.webhook_lock_message || '';
+
+    function setNavTabsLock(locked) {
+        const $tabs = $('.aicp-nav-tab-wrapper [data-lockable-tab="1"]');
+        $tabs.each(function() {
+            const $tab = $(this);
+            if (locked) {
+                $tab.addClass('aicp-nav-tab--disabled')
+                    .attr('aria-disabled', 'true')
+                    .attr('data-tab-disabled', '1')
+                    .data('tabDisabled', 1);
+            } else {
+                $tab.removeClass('aicp-nav-tab--disabled')
+                    .removeAttr('aria-disabled')
+                    .removeAttr('data-tab-disabled')
+                    .removeData('tabDisabled');
+            }
+        });
+    }
 
     // Inicializar color pickers
     $('.aicp-color-picker').wpColorPicker({
@@ -20,11 +39,21 @@ jQuery(function($) {
 
     function handleTabs() {
         $('.aicp-nav-tab-wrapper a').on('click', function(e) {
+            const $tab = $(this);
+            const isDisabled = $tab.attr('aria-disabled') === 'true' || $tab.data('tabDisabled') === 1;
+            if (isDisabled) {
+                e.preventDefault();
+                if (navLockMessage) {
+                    window.alert(navLockMessage);
+                }
+                return;
+            }
+
             e.preventDefault();
             $('.aicp-nav-tab-wrapper a').removeClass('nav-tab-active');
-            $(this).addClass('nav-tab-active');
+            $tab.addClass('nav-tab-active');
             $('.aicp-tab-content').hide();
-            const targetTab = $(this).attr('href');
+            const targetTab = $tab.attr('href');
             $(targetTab).show();
         });
         $('.aicp-tab-content').not(':first').hide();
@@ -306,6 +335,8 @@ jQuery(function($) {
                 $notice.hide();
             }
 
+            setNavTabsLock(locked);
+
             $lockableElements.each(function() {
                 const $el = $(this);
                 if ($el.hasClass('aicp-lock-hidden')) return;
@@ -324,6 +355,8 @@ jQuery(function($) {
         const initialLocked = $toggle.is(':checked') || !!(aicp_admin_params.initial_settings && aicp_admin_params.initial_settings.forward_to_webhook);
         if (initialLocked) {
             setLockedState(true);
+        } else {
+            setNavTabsLock(false);
         }
     }
 


### PR DESCRIPTION
## Summary
- disable the configuration, leads, and PRO tabs when the webhook forwarder is active and surface the same warning copy across the locked sections
- expose the lock message to JavaScript so the tab handler can block navigation and alert the user while styling disabled tabs
- ensure localized data and admin notices reuse the webhook lock message for a consistent experience

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f5042d40a88330b088d0fdc1d39b13