### PR TITLE
Add Chart.js visualizations to analytics dashboard

### DIFF
--- a/ai-chatbot-pro/admin/analytics-page.php
+++ b/ai-chatbot-pro/admin/analytics-page.php
@@ -34,15 +34,94 @@ function aicp_render_analytics_page() {
         'form_leads'     => 0,
         'failed_leads'   => 0,
     ]);
-    $total_conversations = $wpdb->get_var("SELECT COUNT(DISTINCT session_id) FROM $logs_table");
-    $total_leads = $wpdb->get_var("SELECT COUNT(*) FROM $logs_table WHERE has_lead = 1");
+    $total_conversations = $assistant_id > 0
+        ? (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(DISTINCT session_id) FROM $logs_table WHERE assistant_id = %d", $assistant_id))
+        : (int) $wpdb->get_var("SELECT COUNT(DISTINCT session_id) FROM $logs_table");
+
+    $total_leads = $assistant_id > 0
+        ? (int) $wpdb->get_var($wpdb->prepare("SELECT COUNT(DISTINCT session_id) FROM $logs_table WHERE has_lead = 1 AND assistant_id = %d", $assistant_id))
+        : (int) $wpdb->get_var("SELECT COUNT(DISTINCT session_id) FROM $logs_table WHERE has_lead = 1");
     $conversion_rate = $total_conversations > 0 ? round(($total_leads / $total_conversations) * 100, 2) : 0;
-    $top_questions = $wpdb->get_results("SELECT first_user_message, COUNT(*) as count FROM $logs_table WHERE first_user_message != '' GROUP BY first_user_message ORDER BY count DESC LIMIT 5");
+
+    $top_questions = $assistant_id > 0
+        ? $wpdb->get_results($wpdb->prepare("SELECT first_user_message, COUNT(*) as count FROM $logs_table WHERE first_user_message != '' AND assistant_id = %d GROUP BY first_user_message ORDER BY count DESC LIMIT 5", $assistant_id))
+        : $wpdb->get_results("SELECT first_user_message, COUNT(*) as count FROM $logs_table WHERE first_user_message != '' GROUP BY first_user_message ORDER BY count DESC LIMIT 5");
+
+    $days_range = 14;
+    $start_timestamp = strtotime('-' . ($days_range - 1) . ' days', current_time('timestamp'));
+    $start_datetime = date('Y-m-d 00:00:00', $start_timestamp);
+
+    $chart_where = 'timestamp >= %s';
+    $chart_params = [$start_datetime];
+    if ($assistant_id > 0) {
+        $chart_where .= ' AND assistant_id = %d';
+        $chart_params[] = $assistant_id;
+    }
+
+    $chart_query = $wpdb->prepare(
+        "SELECT DATE(timestamp) as day,
+                COUNT(DISTINCT session_id) as conversations,
+                COUNT(DISTINCT CASE WHEN has_lead = 1 THEN session_id END) as leads
+         FROM $logs_table
+         WHERE $chart_where
+         GROUP BY day
+         ORDER BY day ASC",
+        $chart_params
+    );
+
+    $chart_results = $wpdb->get_results($chart_query, ARRAY_A);
+    $chart_map = [];
+    foreach ($chart_results as $row) {
+        $chart_map[$row['day']] = [
+            'conversations' => (int) $row['conversations'],
+            'leads' => (int) $row['leads'],
+        ];
+    }
+
+    $chart_labels = [];
+    $chart_conversations = [];
+    $chart_leads = [];
+    $chart_conversion_rates = [];
+
+    for ($i = 0; $i < $days_range; $i++) {
+        $date_timestamp = strtotime('+' . $i . ' days', $start_timestamp);
+        $date = date('Y-m-d', $date_timestamp);
+        $label = date_i18n('d M', $date_timestamp);
+        $data_for_day = $chart_map[$date] ?? ['conversations' => 0, 'leads' => 0];
+        $conversations = (int) $data_for_day['conversations'];
+        $leads_count = (int) $data_for_day['leads'];
+
+        $chart_labels[] = $label;
+        $chart_conversations[] = $conversations;
+        $chart_leads[] = $leads_count;
+        $chart_conversion_rates[] = $conversations > 0 ? round(($leads_count / $conversations) * 100, 2) : 0;
+    }
+
+    $range_label = sprintf(__('Últimos %d días', 'ai-chatbot-pro'), $days_range);
+
+    wp_enqueue_style('aicp-admin-styles', AICP_PLUGIN_URL . 'assets/css/admin.css', [], AICP_VERSION);
+    wp_enqueue_script('chartjs', 'https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js', [], '4.4.4', true);
+    wp_register_script('aicp-analytics-script', AICP_PLUGIN_URL . 'assets/js/analytics.js', ['chartjs'], AICP_VERSION, true);
+    wp_localize_script('aicp-analytics-script', 'aicpAnalyticsData', [
+        'labels' => $chart_labels,
+        'conversations' => $chart_conversations,
+        'leads' => $chart_leads,
+        'conversionRates' => $chart_conversion_rates,
+        'assistantId' => $assistant_id,
+        'rangeLabel' => $range_label,
+        'i18n' => [
+            'chartTitle' => sprintf(__('Actividad del Chatbot (%s)', 'ai-chatbot-pro'), $range_label),
+            'conversations' => __('Conversaciones', 'ai-chatbot-pro'),
+            'leads' => __('Leads', 'ai-chatbot-pro'),
+            'conversionRate' => __('Tasa de conversión (%)', 'ai-chatbot-pro'),
+        ],
+    ]);
+    wp_enqueue_script('aicp-analytics-script');
 
     ?>
     <div class="wrap" id="aicp-analytics-page">
         <h1><?php _e('Analíticas del Chatbot', 'ai-chatbot-pro'); ?></h1>
-        
+
         <div class="aicp-stats-boxes">
             <div class="aicp-stat-box"><h2><?php echo esc_html($total_conversations); ?></h2><p><?php _e('Conversaciones Totales', 'ai-chatbot-pro'); ?></p></div>
             <div class="aicp-stat-box"><h2><?php echo esc_html($total_leads); ?></h2><p><?php _e('Leads Capturados', 'ai-chatbot-pro'); ?></p></div>
@@ -50,6 +129,14 @@ function aicp_render_analytics_page() {
             <div class="aicp-stat-box"><h2><?php echo esc_html($lead_stats['complete_leads']); ?></h2><p><?php _e('Leads Completos', 'ai-chatbot-pro'); ?></p></div>
             <div class="aicp-stat-box"><h2><?php echo esc_html($lead_stats['partial_leads']); ?></h2><p><?php _e('Leads Incompletos', 'ai-chatbot-pro'); ?></p></div>
             <div class="aicp-stat-box"><h2><?php echo esc_html($lead_stats['calendar_leads']); ?></h2><p><?php _e('Reservas por Calendario', 'ai-chatbot-pro'); ?></p></div>
+        </div>
+
+        <div class="aicp-analytics-section">
+            <h2><?php _e('Actividad Reciente', 'ai-chatbot-pro'); ?></h2>
+            <p class="description"><?php echo esc_html(sprintf(__('Resumen de conversaciones, leads y conversiones (%s).', 'ai-chatbot-pro'), $range_label)); ?></p>
+            <div class="aicp-chart-wrapper">
+                <canvas id="aicp-analytics-chart" height="280"></canvas>
+            </div>
         </div>
 
         <div class="aicp-analytics-section">

--- a/ai-chatbot-pro/assets/css/admin.css
+++ b/ai-chatbot-pro/assets/css/admin.css
@@ -153,6 +153,8 @@
 #aicp-analytics-page .aicp-stat-box h2 { font-size: 2.5em; margin: 0; color: #0073aa; }
 #aicp-analytics-page .aicp-stat-box p { margin: 5px 0 0; font-size: 1.1em; color: #555; }
 #aicp-analytics-page .aicp-analytics-section { margin-top: 40px; background: #fff; padding: 20px; }
+#aicp-analytics-page .aicp-chart-wrapper { position: relative; width: 100%; min-height: 280px; }
+#aicp-analytics-page .aicp-chart-wrapper canvas { width: 100% !important; height: 100% !important; }
 
 /* Previsualización en Vivo */
 #aicp-preview-container {

--- a/ai-chatbot-pro/assets/js/analytics.js
+++ b/ai-chatbot-pro/assets/js/analytics.js
@@ -1,0 +1,118 @@
+(function() {
+    document.addEventListener('DOMContentLoaded', function() {
+        if (typeof aicpAnalyticsData === 'undefined') {
+            return;
+        }
+
+        const canvas = document.getElementById('aicp-analytics-chart');
+        if (!canvas || typeof Chart === 'undefined') {
+            return;
+        }
+
+        const { labels, conversations, leads, conversionRates, i18n } = aicpAnalyticsData;
+
+        new Chart(canvas, {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [
+                    {
+                        label: i18n.conversations,
+                        data: conversations,
+                        borderColor: '#1d4ed8',
+                        backgroundColor: 'rgba(29, 78, 216, 0.15)',
+                        tension: 0.35,
+                        fill: true,
+                        borderWidth: 2,
+                        pointRadius: 3,
+                        pointHoverRadius: 5,
+                        yAxisID: 'y',
+                    },
+                    {
+                        label: i18n.leads,
+                        data: leads,
+                        borderColor: '#059669',
+                        backgroundColor: 'rgba(5, 150, 105, 0.15)',
+                        tension: 0.35,
+                        fill: true,
+                        borderWidth: 2,
+                        pointRadius: 3,
+                        pointHoverRadius: 5,
+                        yAxisID: 'y',
+                    },
+                    {
+                        label: i18n.conversionRate,
+                        data: conversionRates,
+                        borderColor: '#f97316',
+                        backgroundColor: '#f97316',
+                        tension: 0.35,
+                        fill: false,
+                        borderWidth: 2,
+                        borderDash: [6, 6],
+                        pointRadius: 3,
+                        pointHoverRadius: 5,
+                        yAxisID: 'y1',
+                    }
+                ]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: {
+                        position: 'bottom',
+                    },
+                    title: {
+                        display: Boolean(i18n.chartTitle),
+                        text: i18n.chartTitle,
+                        padding: {
+                            top: 10,
+                            bottom: 20
+                        },
+                    },
+                    tooltip: {
+                        mode: 'index',
+                        intersect: false,
+                    }
+                },
+                interaction: {
+                    mode: 'index',
+                    intersect: false,
+                },
+                scales: {
+                    y: {
+                        beginAtZero: true,
+                        title: {
+                            display: true,
+                            text: i18n.conversations,
+                        },
+                        grid: {
+                            drawBorder: false,
+                        }
+                    },
+                    y1: {
+                        beginAtZero: true,
+                        position: 'right',
+                        title: {
+                            display: true,
+                            text: i18n.conversionRate,
+                        },
+                        grid: {
+                            drawBorder: false,
+                            drawOnChartArea: false,
+                        }
+                    },
+                    x: {
+                        ticks: {
+                            maxRotation: 0,
+                            autoSkip: true,
+                        },
+                        grid: {
+                            drawBorder: false,
+                        }
+                    }
+                }
+            }
+        });
+    });
+})();


### PR DESCRIPTION
## Summary
- integrate Chart.js into the analytics admin page to visualise conversations, leads, and conversion trends
- load dynamic datasets from existing chat logs with assistant scoping and expose them to the browser
- add supporting JavaScript and styling for the new chart component

## Testing
- php -l ai-chatbot-pro/admin/analytics-page.php

------
https://chatgpt.com/codex/tasks/task_e_68f50434d524833093c6806b4e373ea2