### PR TITLE
Add webhook test button and diagnostics for integrations

### DIFF
--- a/ai-chatbot-pro/admin/assistant-meta-boxes.php
+++ b/ai-chatbot-pro/admin/assistant-meta-boxes.php
@@ -111,6 +111,7 @@ function aicp_admin_scripts($hook) {
         'delete_nonce' => wp_create_nonce('aicp_delete_log_nonce'),
         'get_log_nonce' => wp_create_nonce('aicp_get_log_nonce'),
         'capture_lead_nonce' => wp_create_nonce('aicp_capture_lead_nonce'),
+        'test_webhook_nonce' => wp_create_nonce('aicp_test_webhook_nonce'),
         'default_bot_avatar' => $default_bot_avatar,
         'default_user_avatar' => $default_user_avatar,
         'default_open_icon' => $default_open_icon,
@@ -137,6 +138,18 @@ function aicp_admin_scripts($hook) {
         'meta' => $meta,
         'webhook_warning' => __('Si activas el reenvío al webhook externo, el asistente ignorará las instrucciones internas y no podrás editarlas hasta desactivar la integración. ¿Deseas continuar?', 'ai-chatbot-pro'),
         'webhook_lock_message' => __('La integración con webhook está activa. Desactívala para volver a entrenar el asistente o modificar estas opciones PRO.', 'ai-chatbot-pro'),
+        'test_webhook_labels' => [
+            'empty_url'      => __('Introduce una URL de webhook antes de lanzar la prueba.', 'ai-chatbot-pro'),
+            'request_error'  => __('No se pudo completar la solicitud. Revisa la consola o inténtalo de nuevo.', 'ai-chatbot-pro'),
+            'success_title'  => __('El webhook respondió correctamente.', 'ai-chatbot-pro'),
+            'error_title'    => __('El webhook devolvió un error.', 'ai-chatbot-pro'),
+            'http_status'    => __('Código HTTP', 'ai-chatbot-pro'),
+            'reply'          => __('Respuesta del webhook', 'ai-chatbot-pro'),
+            'metadata'       => __('Metadatos recibidos', 'ai-chatbot-pro'),
+            'metadata_empty' => __('El webhook no devolvió metadatos.', 'ai-chatbot-pro'),
+            'payload'        => __('Payload enviado', 'ai-chatbot-pro'),
+            'raw_body'       => __('Cuerpo de la respuesta', 'ai-chatbot-pro'),
+        ],
     ]);
 }
 add_action('admin_enqueue_scripts', 'aicp_admin_scripts');
@@ -314,6 +327,13 @@ function aicp_render_integrations_tab($assistant_id, $v) {
     echo '<tr><th><label for="aicp_forward_webhook_timeout">' . __('Tiempo de espera', 'ai-chatbot-pro') . '</label></th>';
     echo '<td><input type="number" min="5" max="120" name="aicp_settings[forward_webhook_timeout]" id="aicp_forward_webhook_timeout" value="' . esc_attr($timeout) . '" class="small-text" /> ' . __('segundos', 'ai-chatbot-pro');
     echo '<p class="description">' . __('El chatbot mostrará el error si el webhook no responde a tiempo.', 'ai-chatbot-pro') . '</p></td></tr>';
+
+    echo '<tr><th>' . __('Probar conexión', 'ai-chatbot-pro') . '</th>';
+    echo '<td><button type="button" class="button button-secondary" id="aicp_test_webhook_button">' . esc_html__('Enviar mensaje de prueba', 'ai-chatbot-pro') . '</button>';
+    echo ' <span class="spinner" id="aicp_test_webhook_spinner" style="float:none;margin-top:0;"></span>';
+    echo '<p class="description">' . __('Envía un mensaje de prueba al webhook y revisa la respuesta sin salir del editor.', 'ai-chatbot-pro') . '</p>';
+    echo '<div id="aicp_test_webhook_feedback" class="notice" style="display:none;" aria-live="polite" role="status"></div>';
+    echo '</td></tr>';
 
     echo '</tbody></table>';
 

--- a/ai-chatbot-pro/assets/js/admin-scripts.js
+++ b/ai-chatbot-pro/assets/js/admin-scripts.js
@@ -9,6 +9,21 @@ jQuery(function($) {
     const escapeHtml = (text) => $('<div/>').text(text == null ? '' : String(text)).html();
     const navLockMessage = aicp_admin_params.webhook_lock_message || '';
 
+    const formatJsonBlock = (value) => {
+        if (value == null) {
+            return '';
+        }
+
+        let jsonString = '';
+        try {
+            jsonString = JSON.stringify(value, null, 2);
+        } catch (error) {
+            jsonString = String(value);
+        }
+
+        return `<pre>${escapeHtml(jsonString)}</pre>`;
+    };
+
     function setNavTabsLock(locked) {
         const $tabs = $('.aicp-nav-tab-wrapper [data-lockable-tab="1"]');
         $tabs.each(function() {
@@ -85,6 +100,141 @@ jQuery(function($) {
             
             $('#' + targetId + '_url').val(defaultImage).trigger('change');
             $('#' + targetId + '_preview').attr('src', defaultImage);
+        });
+    }
+
+    function handleWebhookTestButton() {
+        const $button = $('#aicp_test_webhook_button');
+        const nonce = aicp_admin_params.test_webhook_nonce;
+        if (!$button.length || !nonce) {
+            return;
+        }
+
+        const labels = aicp_admin_params.test_webhook_labels || {};
+        const $spinner = $('#aicp_test_webhook_spinner');
+        const $feedback = $('#aicp_test_webhook_feedback');
+        const $urlField = $('#aicp_forward_webhook_url');
+        const $secretField = $('#aicp_forward_webhook_secret');
+        const $timeoutField = $('#aicp_forward_webhook_timeout');
+        let currentRequest = null;
+
+        function resetFeedback() {
+            $feedback.removeClass('notice-success notice-error notice-info').hide().empty();
+        }
+
+        function showFeedback(type, html) {
+            resetFeedback();
+            $feedback.addClass('notice').addClass(`notice-${type}`).html(html).show();
+        }
+
+        $button.on('click', function(e) {
+            e.preventDefault();
+            if ($button.prop('disabled')) {
+                return;
+            }
+
+            const urlValue = ($urlField.val() || '').trim();
+            if (!urlValue) {
+                const message = labels.empty_url || 'Introduce una URL de webhook antes de lanzar la prueba.';
+                showFeedback('error', `<p>${escapeHtml(message)}</p>`);
+                return;
+            }
+
+            if (currentRequest && typeof currentRequest.abort === 'function') {
+                currentRequest.abort();
+            }
+
+            resetFeedback();
+            $button.prop('disabled', true);
+            $spinner.addClass('is-active');
+
+            const requestData = {
+                action: 'aicp_test_webhook',
+                nonce,
+                assistant_id: aicp_admin_params.assistant_id || 0,
+                webhook_url: urlValue,
+                secret: $secretField.val() || '',
+                timeout: $timeoutField.val() || ''
+            };
+
+            currentRequest = $.ajax({
+                url: aicp_admin_params.ajax_url,
+                method: 'POST',
+                dataType: 'json',
+                data: requestData,
+            }).done(function(response) {
+                if (response && response.success) {
+                    const data = response.data || {};
+                    let html = `<p><strong>${escapeHtml(data.message || labels.success_title || '')}</strong></p>`;
+
+                    if (data.http_status) {
+                        html += `<p>${escapeHtml(labels.http_status || 'Código HTTP')}: <code>${escapeHtml(String(data.http_status))}</code></p>`;
+                    }
+
+                    if (data.reply) {
+                        html += `<p>${escapeHtml(labels.reply || 'Respuesta del webhook')}:</p><pre>${escapeHtml(data.reply)}</pre>`;
+                    }
+
+                    if (data.metadata) {
+                        const metadataIsObject = typeof data.metadata === 'object' && data.metadata !== null;
+                        if (metadataIsObject) {
+                            const metadataKeys = Object.keys(data.metadata);
+                            if (metadataKeys.length === 0) {
+                                if (labels.metadata_empty) {
+                                    html += `<p>${escapeHtml(labels.metadata_empty)}</p>`;
+                                }
+                            } else {
+                                html += `<p>${escapeHtml(labels.metadata || 'Metadatos recibidos')}:</p>${formatJsonBlock(data.metadata)}`;
+                            }
+                        } else {
+                            html += `<p>${escapeHtml(labels.metadata || 'Metadatos recibidos')}:</p><pre>${escapeHtml(String(data.metadata))}</pre>`;
+                        }
+                    }
+
+                    if (data.payload) {
+                        html += `<p>${escapeHtml(labels.payload || 'Payload enviado')}:</p>${formatJsonBlock(data.payload)}`;
+                    }
+
+                    if (data.raw_body) {
+                        html += `<p>${escapeHtml(labels.raw_body || 'Cuerpo de la respuesta')}:</p><pre>${escapeHtml(data.raw_body)}</pre>`;
+                    }
+
+                    showFeedback('success', html);
+                } else {
+                    const data = response && response.data ? response.data : {};
+                    let html = '';
+                    const errorTitle = labels.error_title || '';
+                    if (errorTitle) {
+                        html += `<p><strong>${escapeHtml(errorTitle)}</strong></p>`;
+                    }
+                    if (data.message) {
+                        html += `<p>${escapeHtml(data.message)}</p>`;
+                    }
+                    if (data.http_status) {
+                        html += `<p>${escapeHtml(labels.http_status || 'Código HTTP')}: <code>${escapeHtml(String(data.http_status))}</code></p>`;
+                    }
+                    if (data.payload) {
+                        html += `<p>${escapeHtml(labels.payload || 'Payload enviado')}:</p>${formatJsonBlock(data.payload)}`;
+                    }
+                    if (data.raw_body) {
+                        html += `<p>${escapeHtml(labels.raw_body || 'Cuerpo de la respuesta')}:</p><pre>${escapeHtml(data.raw_body)}</pre>`;
+                    }
+                    if (!html) {
+                        html = `<p>${escapeHtml(labels.request_error || 'No se pudo completar la solicitud. Revisa la consola o inténtalo de nuevo.')}</p>`;
+                    }
+                    showFeedback('error', html);
+                }
+            }).fail(function(_jqXHR, textStatus) {
+                if (textStatus === 'abort') {
+                    return;
+                }
+                const message = labels.request_error || 'No se pudo completar la solicitud. Revisa la consola o inténtalo de nuevo.';
+                showFeedback('error', `<p>${escapeHtml(message)}</p>`);
+            }).always(function() {
+                $spinner.removeClass('is-active');
+                $button.prop('disabled', false);
+                currentRequest = null;
+            });
         });
     }
     
@@ -943,6 +1093,7 @@ jQuery(function($) {
         handleDeleteLogFromList();
         initTemplateSelector();
         handleCustomPromptToggle();
+        handleWebhookTestButton();
         handleWebhookToggle();
         handleLeadsLock();
         handleProTabLock();

--- a/ai-chatbot-pro/includes/class-ajax-handler.php
+++ b/ai-chatbot-pro/includes/class-ajax-handler.php
@@ -13,6 +13,7 @@ class AICP_Ajax_Handler {
         add_action('wp_ajax_nopriv_aicp_chat_request', [__CLASS__, 'handle_chat_request']);
         add_action('wp_ajax_aicp_delete_log', [__CLASS__, 'handle_delete_log']);
         add_action('wp_ajax_aicp_get_log_details', [__CLASS__, 'handle_get_log_details']);
+        add_action('wp_ajax_aicp_test_webhook', [__CLASS__, 'handle_test_webhook']);
         add_action('wp_ajax_nopriv_aicp_submit_feedback', [__CLASS__, 'handle_submit_feedback']);
         add_action('wp_ajax_aicp_submit_feedback', [__CLASS__, 'handle_submit_feedback']);
         add_action('wp_ajax_aicp_submit_lead_form', [__CLASS__, 'handle_submit_lead_form']);
@@ -165,14 +166,26 @@ class AICP_Ajax_Handler {
         ]);
 
         if (is_wp_error($response)) {
-            return $response;
+            return new WP_Error(
+                $response->get_error_code(),
+                $response->get_error_message(),
+                [
+                    'http_status'      => 0,
+                    'request_payload'  => $payload,
+                ]
+            );
         }
 
         $status = wp_remote_retrieve_response_code($response);
         if ($status >= 400) {
             return new WP_Error(
                 'webhook_http_error',
-                sprintf(__('El webhook devolvió un código HTTP %d.', 'ai-chatbot-pro'), $status)
+                sprintf(__('El webhook devolvió un código HTTP %d.', 'ai-chatbot-pro'), $status),
+                [
+                    'http_status'     => $status,
+                    'response_body'   => wp_remote_retrieve_body($response),
+                    'request_payload' => $payload,
+                ]
             );
         }
 
@@ -180,16 +193,35 @@ class AICP_Ajax_Handler {
         $data = json_decode($body, true);
 
         if (!is_array($data)) {
-            return new WP_Error('webhook_invalid_json', __('El webhook respondió con un JSON inválido.', 'ai-chatbot-pro'));
+            return new WP_Error(
+                'webhook_invalid_json',
+                __('El webhook respondió con un JSON inválido.', 'ai-chatbot-pro'),
+                [
+                    'http_status'     => $status,
+                    'response_body'   => $body,
+                    'request_payload' => $payload,
+                ]
+            );
         }
 
         if (!isset($data['reply']) || !is_string($data['reply']) || '' === trim($data['reply'])) {
-            return new WP_Error('webhook_missing_reply', __('El webhook no devolvió el campo "reply" con el texto de respuesta.', 'ai-chatbot-pro'));
+            return new WP_Error(
+                'webhook_missing_reply',
+                __('El webhook no devolvió el campo "reply" con el texto de respuesta.', 'ai-chatbot-pro'),
+                [
+                    'http_status'     => $status,
+                    'response_body'   => $body,
+                    'request_payload' => $payload,
+                ]
+            );
         }
 
         $result = [
             'reply'     => sanitize_textarea_field($data['reply']),
             'metadata'  => [],
+            'http_status' => $status,
+            'raw_body'    => $body,
+            'request_payload' => $payload,
         ];
 
         if (isset($data['metadata']) && is_array($data['metadata'])) {
@@ -197,6 +229,103 @@ class AICP_Ajax_Handler {
         }
 
         return $result;
+    }
+
+    public static function handle_test_webhook() {
+        check_ajax_referer('aicp_test_webhook_nonce', 'nonce');
+
+        $assistant_id = isset($_POST['assistant_id']) ? absint($_POST['assistant_id']) : 0;
+
+        if ($assistant_id > 0) {
+            if (!current_user_can('edit_post', $assistant_id)) {
+                wp_send_json_error(['message' => __('No tienes permisos para realizar esta acción.', 'ai-chatbot-pro')]);
+            }
+        } else {
+            if (!current_user_can('edit_posts')) {
+                wp_send_json_error(['message' => __('No tienes permisos para realizar esta acción.', 'ai-chatbot-pro')]);
+            }
+        }
+
+        $webhook_url = isset($_POST['webhook_url']) ? esc_url_raw(wp_unslash($_POST['webhook_url'])) : '';
+        if (empty($webhook_url) || !wp_http_validate_url($webhook_url)) {
+            wp_send_json_error(['message' => __('Introduce una URL de webhook válida antes de probar la conexión.', 'ai-chatbot-pro')]);
+        }
+
+        $secret = isset($_POST['secret']) ? sanitize_text_field(wp_unslash($_POST['secret'])) : '';
+        $timeout = isset($_POST['timeout']) ? intval($_POST['timeout']) : 15;
+        $timeout = max(5, min(120, $timeout));
+
+        $settings = [];
+        if ($assistant_id > 0) {
+            $settings = get_post_meta($assistant_id, '_aicp_assistant_settings', true);
+        }
+        if (!is_array($settings)) {
+            $settings = [];
+        }
+
+        $test_settings = $settings;
+        $test_settings['forward_webhook_url'] = $webhook_url;
+        $test_settings['forward_webhook_secret'] = $secret;
+        $test_settings['forward_webhook_timeout'] = $timeout;
+
+        $system_prompt = '';
+        if (!class_exists('AICP_Prompt_Builder')) {
+            require_once AICP_PLUGIN_DIR . 'includes/class-prompt-builder.php';
+        }
+        $system_prompt = AICP_Prompt_Builder::build($settings, '');
+
+        $conversation = [];
+        if ('' !== trim($system_prompt)) {
+            $conversation[] = [
+                'role'    => 'system',
+                'content' => $system_prompt,
+            ];
+        }
+
+        $test_message = __('Mensaje de prueba desde WordPress para comprobar el webhook.', 'ai-chatbot-pro');
+        $conversation[] = [
+            'role'    => 'user',
+            'content' => $test_message,
+        ];
+
+        $session_id = 'aicp_test_' . wp_generate_uuid4();
+        $page_context = __('Prueba manual del webhook desde el panel de administración.', 'ai-chatbot-pro');
+
+        $result = self::call_message_webhook($assistant_id, $test_settings, $session_id, $conversation, $page_context, [], $system_prompt);
+
+        if (is_wp_error($result)) {
+            $error_data = ['message' => $result->get_error_message()];
+            $extra = $result->get_error_data();
+            if (is_array($extra)) {
+                if (isset($extra['http_status'])) {
+                    $error_data['http_status'] = intval($extra['http_status']);
+                }
+                if (isset($extra['response_body'])) {
+                    $error_data['raw_body'] = $extra['response_body'];
+                }
+                if (isset($extra['request_payload'])) {
+                    $error_data['payload'] = $extra['request_payload'];
+                }
+            }
+            wp_send_json_error($error_data);
+        }
+
+        $response = [
+            'message'      => __('El webhook respondió correctamente.', 'ai-chatbot-pro'),
+            'http_status'  => $result['http_status'] ?? null,
+            'reply'        => $result['reply'],
+            'payload'      => $result['request_payload'] ?? [],
+        ];
+
+        if (!empty($result['metadata'])) {
+            $response['metadata'] = $result['metadata'];
+        }
+
+        if (!empty($result['raw_body'])) {
+            $response['raw_body'] = $result['raw_body'];
+        }
+
+        wp_send_json_success($response);
     }
 
     public static function handle_get_templates() {


### PR DESCRIPTION
## Summary
- add an admin-side “probar conexión” control so editors can trigger a webhook test from the assistant settings
- expose an authenticated AJAX endpoint that reuses the webhook payload and returns status, body, and metadata for debugging
- extend the admin script to call the test endpoint, surface formatted payload/response details, and localize new helper strings

## Testing
- php -l ai-chatbot-pro/includes/class-ajax-handler.php
- php -l ai-chatbot-pro/admin/assistant-meta-boxes.php

------
https://chatgpt.com/codex/tasks/task_e_68f514bce9d88330930d2285dbc8dee1