### PR TITLE
Add multi-provider drivers and simplify prompt settings

### DIFF
--- a/ai-chatbot-pro/admin/assistant-meta-boxes.php
+++ b/ai-chatbot-pro/admin/assistant-meta-boxes.php
@@ -127,12 +127,8 @@ function aicp_admin_scripts($hook) {
             'color_bot_text' => $settings['color_bot_text'] ?? '#333333',
             'color_user_bg' => $settings['color_user_bg'] ?? '#dcf8c6',
             'color_user_text' => $settings['color_user_text'] ?? '#000000',
-            'template_id' => $settings['template_id'] ?? '',
-            'persona' => $settings['persona'] ?? '',
-            'objective' => $settings['objective'] ?? '',
-            'length_tone' => $settings['length_tone'] ?? '',
-            'example' => $settings['example'] ?? '',
-            'quick_replies' => is_array($settings['quick_replies'] ?? null) ? $settings['quick_replies'] : [],
+            'provider' => $settings['provider'] ?? 'openai',
+            'master_prompt' => $settings['master_prompt'] ?? '',
             'forward_to_webhook' => !empty($settings['forward_to_webhook']),
         ],
         'meta' => $meta,
@@ -219,10 +215,7 @@ function aicp_render_main_meta_box($post) {
 }
 
 function aicp_render_instructions_tab($v) {
-    if (!class_exists('AICP_Prompt_Builder')) {
-        require_once AICP_PLUGIN_DIR . 'includes/class-prompt-builder.php';
-    }
-    $prompt = $v['custom_prompt'] ?? ($v['compiled_prompt'] ?? AICP_Prompt_Builder::build($v));
+    $prompt = $v['master_prompt'] ?? '';
     $is_forwarding_enabled = !empty($v['forward_to_webhook']);
     ?>
     <div class="notice notice-warning inline aicp-instructions-lock-notice"<?php echo $is_forwarding_enabled ? '' : ' style="display:none;"'; ?>>
@@ -232,38 +225,22 @@ function aicp_render_instructions_tab($v) {
         <table class="form-table">
 
         <tr>
-            <th><label for="aicp_model"><?php _e('Modelo de IA', 'ai-chatbot-pro'); ?></label></th>
+            <th><label for="aicp_provider"><?php _e('Proveedor de modelo', 'ai-chatbot-pro'); ?></label></th>
             <td>
-                <select name="aicp_settings[model]" id="aicp_model" class="regular-text">
-                    <?php
-                    $model = isset($v['model']) && isset(AICP_AVAILABLE_MODELS[$v['model']]) ? $v['model'] : array_key_first(AICP_AVAILABLE_MODELS);
-                    foreach (AICP_AVAILABLE_MODELS as $value => $label) {
-                        printf('<option value="%s" %s>%s</option>', esc_attr($value), selected($model, $value, false), esc_html($label));
-                    }
-                    ?>
+                <?php $provider = $v['provider'] ?? 'openai'; ?>
+                <select name="aicp_settings[provider]" id="aicp_provider">
+                    <option value="openai" <?php selected($provider, 'openai'); ?>><?php _e('OpenAI / ChatGPT', 'ai-chatbot-pro'); ?></option>
+                    <option value="gemini" <?php selected($provider, 'gemini'); ?>><?php _e('Google Gemini', 'ai-chatbot-pro'); ?></option>
+                    <option value="custom" <?php selected($provider, 'custom'); ?>><?php _e('Otro proveedor', 'ai-chatbot-pro'); ?></option>
                 </select>
+                <p class="description"><?php _e('Elige qué driver se usará para procesar el prompt maestro.', 'ai-chatbot-pro'); ?></p>
             </td>
         </tr>
         <tr>
-            <th><label for="aicp_template_id"><?php _e('Plantilla', 'ai-chatbot-pro'); ?></label></th>
+            <th><label for="aicp_master_prompt"><?php _e('Prompt maestro', 'ai-chatbot-pro'); ?></label></th>
             <td>
-                <select name="aicp_settings[template_id]" id="aicp_template_id">
-                    <option value=""><?php _e('Selecciona una plantilla', 'ai-chatbot-pro'); ?></option>
-                </select>
-                <p class="description"><?php _e('Al seleccionar una plantilla, los campos de abajo se rellenarán automáticamente con un contenido base que puedes personalizar. Si la editas, tu versión personalizada se guardará.', 'ai-chatbot-pro'); ?></p>
-            </td>
-        </tr>
-
-        <tr><th><label for="aicp_persona"><?php _e('Nombre y Personalidad', 'ai-chatbot-pro'); ?></label></th><td><textarea name="aicp_settings[persona]" id="aicp_persona" rows="3" class="large-text"><?php echo esc_textarea($v['persona'] ?? ''); ?></textarea></td></tr>
-        <tr><th><label for="aicp_objective"><?php _e('Objetivo Principal', 'ai-chatbot-pro'); ?></label></th><td><textarea name="aicp_settings[objective]" id="aicp_objective" rows="2" class="large-text"><?php echo esc_textarea($v['objective'] ?? ''); ?></textarea></td></tr>
-        <tr><th><label for="aicp_length_tone"><?php _e('Longitud y Tono', 'ai-chatbot-pro'); ?></label></th><td><textarea name="aicp_settings[length_tone]" id="aicp_length_tone" rows="3" class="large-text"><?php echo esc_textarea($v['length_tone'] ?? ''); ?></textarea></td></tr>
-        <tr><th><label for="aicp_example"><?php _e('Ejemplo de Respuesta', 'ai-chatbot-pro'); ?></label></th><td><textarea name="aicp_settings[example]" id="aicp_example" rows="5" class="large-text"><?php echo esc_textarea($v['example'] ?? ''); ?></textarea></td></tr>
-        <tr><th><label><?php _e('Respuestas Rápidas', 'ai-chatbot-pro'); ?></label></th><td><input type="text" name="aicp_settings[quick_replies][]" value="<?php echo esc_attr($v['quick_replies'][0] ?? ''); ?>" class="large-text" placeholder="<?php _e('Ej: Me interesa el servicio de SEO', 'ai-chatbot-pro'); ?>"><br><input type="text" name="aicp_settings[quick_replies][]" value="<?php echo esc_attr($v['quick_replies'][1] ?? ''); ?>" class="large-text" placeholder="<?php _e('Ej: Quiero una web económica', 'ai-chatbot-pro'); ?>"><br><input type="text" name="aicp_settings[quick_replies][]" value="<?php echo esc_attr($v['quick_replies'][2] ?? ''); ?>" class="large-text" placeholder="<?php _e('Ej: ¿Podéis llamarme?', 'ai-chatbot-pro'); ?>"><p class="description"><?php _e('Estas respuestas aparecerán como botones clicables para el usuario.', 'ai-chatbot-pro'); ?></p></td></tr>
-        <tr>
-            <th><label for="aicp_custom_prompt"><?php _e('Prompt generado', 'ai-chatbot-pro'); ?></label></th>
-            <td>
-                <textarea name="aicp_settings[custom_prompt]" id="aicp_custom_prompt" rows="8" class="large-text" readonly><?php echo esc_textarea($prompt); ?></textarea>
-                <p><label><input type="checkbox" name="aicp_settings[use_custom_prompt]" id="aicp_edit_prompt_toggle" <?php checked(!empty($v['custom_prompt'])); ?>> <?php _e('Editar manualmente', 'ai-chatbot-pro'); ?></label></p>
+                <textarea name="aicp_settings[master_prompt]" id="aicp_master_prompt" rows="12" class="large-text" placeholder="<?php esc_attr_e('Escribe aquí todas las instrucciones del asistente en un solo bloque.', 'ai-chatbot-pro'); ?>"><?php echo esc_textarea($prompt); ?></textarea>
+                <p class="description"><?php _e('El prompt completo se guarda tal cual y define el comportamiento del chatbot.', 'ai-chatbot-pro'); ?></p>
             </td>
         </tr>
         </table>
@@ -349,57 +326,9 @@ function aicp_render_integrations_tab($assistant_id, $v) {
 }
 
 function aicp_render_leads_tab($assistant_id, $v) {
-    global $wpdb;
     $logs_table = $wpdb->prefix . 'aicp_chat_logs';
 
-    $auto_collect = !empty($v['lead_auto_collect']);
-    $lead_email   = $v['lead_email'] ?? '';
-    $webhook      = esc_url($v['webhook_url'] ?? '');
-    $calendar_url = esc_url($v['calendar_url'] ?? '');
-    $integration_active = !empty($v['forward_to_webhook']) && !empty($v['forward_webhook_url']);
-    
-    // Nuevo campo para los campos de lead dinámicos
-    $lead_fields = isset($v['lead_fields']) && is_array($v['lead_fields']) ? $v['lead_fields'] : [];
-
-    echo '<h4>' . __('Ajustes de Captura de Leads', 'ai-chatbot-pro') . '</h4>';
-
-    $notice_style = $integration_active ? '' : ' style="display:none;"';
-    echo '<div class="notice notice-warning inline aicp-leads-lock-notice"' . $notice_style . '><p>' . __('La integración con webhook está activa. Desactívala para volver a entrenar el asistente o modificar estas opciones PRO.', 'ai-chatbot-pro') . '</p></div>';
-
-    $fieldset_classes = 'aicp-lead-settings';
-    if ($integration_active) {
-        $fieldset_classes .= ' aicp-lead-settings--locked';
-    }
-
-    echo '<fieldset class="' . esc_attr($fieldset_classes) . '">';
-    echo '<table class="form-table"><tbody>';
-    echo '<tr><th><label>' . __('Captura Automática', 'ai-chatbot-pro') . '</label></th><td><label><input type="checkbox" name="aicp_settings[lead_auto_collect]" value="1" ' . checked($auto_collect, true, false) . '> ' . __('Solicitar datos de contacto automáticamente', 'ai-chatbot-pro') . '</label></td></tr>';
-    echo '<tr><th><label for="aicp_lead_email">' . __('Email de notificación', 'ai-chatbot-pro') . '</label></th><td><input type="email" id="aicp_lead_email" name="aicp_settings[lead_email]" value="' . esc_attr($lead_email) . '" class="regular-text" /><br /><span class="description">' . sprintf(__('Si se deja vacío, se usará %s.', 'ai-chatbot-pro'), esc_html(get_option('admin_email'))) . '</span></td></tr>';
-    echo '<tr><th><label for="aicp_webhook_url">' . __('Webhook URL', 'ai-chatbot-pro') . '</label></th><td><input type="url" name="aicp_settings[webhook_url]" id="aicp_webhook_url" value="' . esc_attr($webhook) . '" class="regular-text" placeholder="https://example.com/webhook" /></td></tr>';
-    echo '<tr><th><label for="aicp_calendar_url">' . __('URL del Calendario para Reservar Cita', 'ai-chatbot-pro') . '</label></th><td><input type="url" name="aicp_settings[calendar_url]" id="aicp_calendar_url" value="' . esc_attr($calendar_url) . '" class="regular-text" placeholder="https://example.com/agenda" /><br /><span class="description">' . __('Si se configura, el asistente mostrará un botón para reservar una cita cuando detecte intención de agendar.', 'ai-chatbot-pro') . '</span></td></tr>';
-    echo '</tbody></table>';
-
-    // Sección para campos de lead dinámicos
-    echo '<h4>' . __('Campos de Lead Personalizados', 'ai-chatbot-pro') . '</h4>';
-    echo '<p class="description">' . __('Añade los campos de información específica que el asistente debe capturar.', 'ai-chatbot-pro') . '</p>';
-    echo '<table class="form-table aicp-lead-fields-table"><thead><tr><th>' . __('Etiqueta', 'ai-chatbot-pro') . '</th><th>' . __('Nombre de Campo', 'ai-chatbot-pro') . '</th><th>' . __('Tipo', 'ai-chatbot-pro') . '</th><th>' . __('Requerido', 'ai-chatbot-pro') . '</th><th>' . __('Acciones', 'ai-chatbot-pro') . '</th></tr></thead><tbody>';
-
-    foreach ($lead_fields as $field) {
-        $required = isset($field['required']) && $field['required'] === '1' ? '1' : '0';
-        echo '<tr>';
-        echo '<td><input type="text" name="aicp_settings[lead_fields][' . esc_attr($field['name']) . '][label]" value="' . esc_attr($field['label']) . '" /></td>';
-        echo '<td><input type="text" name="aicp_settings[lead_fields][' . esc_attr($field['name']) . '][name]" value="' . esc_attr($field['name']) . '" readonly /></td>';
-        echo '<td><select name="aicp_settings[lead_fields][' . esc_attr($field['name']) . '][type]"><option value="text" ' . selected($field['type'], 'text', false) . '>Texto</option><option value="email" ' . selected($field['type'], 'email', false) . '>Email</option><option value="phone" ' . selected($field['type'], 'phone', false) . '>Teléfono</option><option value="date" ' . selected($field['type'], 'date', false) . '>Fecha</option></select></td>';
-        echo '<td><input type="checkbox" name="aicp_settings[lead_fields][' . esc_attr($field['name']) . '][required]" value="1" ' . checked($required, '1', false) . ' /></td>';
-        echo '<td><button type="button" class="button button-link-delete aicp-remove-lead-field">X</button></td>';
-        echo '</tr>';
-    }
-    
-    echo '</tbody></table>';
-    $add_button_attr = $integration_active ? ' disabled="disabled" aria-disabled="true"' : '';
-    echo '<button type="button" class="button aicp-add-lead-field"' . $add_button_attr . '>' . __('Añadir Campo', 'ai-chatbot-pro') . '</button>';
-    echo '</fieldset>';
-
+    echo '<p>' . __('El historial muestra las conversaciones y los datos estructurados capturados automáticamente. Los ajustes de leads se simplifican a los datos detectados dentro de cada conversación.', 'ai-chatbot-pro') . '</p>';
     // Historial de Conversaciones
     $table_name = $wpdb->prefix . 'aicp_chat_logs';
 
@@ -526,50 +455,11 @@ function aicp_save_meta_box_data($post_id) {
 
     if (!$lock_sections) {
         // Instrucciones
-        if (isset($s['model'])) {
-            $model = sanitize_text_field($s['model']);
-            $current['model'] = array_key_exists($model, AICP_AVAILABLE_MODELS) ? $model : array_key_first(AICP_AVAILABLE_MODELS);
-        } else {
-            $current['model'] = array_key_first(AICP_AVAILABLE_MODELS);
-        }
-        $current['persona'] = isset($s['persona']) ? sanitize_textarea_field($s['persona']) : '';
-        $current['objective'] = isset($s['objective']) ? sanitize_textarea_field($s['objective']) : '';
-        $current['length_tone'] = isset($s['length_tone']) ? sanitize_textarea_field($s['length_tone']) : '';
-        $current['example'] = isset($s['example']) ? sanitize_textarea_field($s['example']) : '';
-        $current['template_id'] = isset($s['template_id']) ? sanitize_text_field($s['template_id']) : '';
+        $current['provider'] = isset($s['provider']) ? sanitize_key($s['provider']) : 'openai';
+        $current['master_prompt'] = isset($s['master_prompt']) ? wp_kses_post(wp_unslash($s['master_prompt'])) : '';
 
-        if (isset($s['quick_replies']) && is_array($s['quick_replies'])) {
-            $current['quick_replies'] = array_map('sanitize_text_field', $s['quick_replies']);
-        }
-
-        if (!empty($s['use_custom_prompt']) && isset($s['custom_prompt'])) {
-            $current['custom_prompt'] = sanitize_textarea_field($s['custom_prompt']);
-        } else {
-            unset($current['custom_prompt']);
-        }
-
-        $current['compiled_prompt'] = sanitize_textarea_field(aicp_compile_prompt($current));
-
-        // Ajustes de captura de leads
-        $current['lead_auto_collect'] = !empty($s['lead_auto_collect']) ? 1 : 0;
-        $current['lead_email']        = isset($s['lead_email']) ? sanitize_email($s['lead_email']) : '';
-        $current['webhook_url']       = isset($s['webhook_url']) ? esc_url_raw($s['webhook_url']) : '';
-        $current['calendar_url']      = isset($s['calendar_url']) ? esc_url_raw($s['calendar_url']) : '';
-
-        // Guardar los nuevos campos de lead dinámicos
-        $current['lead_fields'] = [];
-        if (isset($s['lead_fields']) && is_array($s['lead_fields'])) {
-            foreach ($s['lead_fields'] as $field) {
-                if (!empty($field['name'])) {
-                    $current['lead_fields'][sanitize_key($field['name'])] = [
-                        'label' => sanitize_text_field($field['label'] ?? ''),
-                        'name' => sanitize_key($field['name']),
-                        'type' => sanitize_key($field['type'] ?? 'text'),
-                        'required' => isset($field['required']) ? 1 : 0,
-                    ];
-                }
-            }
-        }
+        // Ajustes de captura de leads simplificados
+        $current['lead_history_enabled'] = 1;
     }
 
     // Diseño

--- a/ai-chatbot-pro/admin/settings-page.php
+++ b/ai-chatbot-pro/admin/settings-page.php
@@ -27,11 +27,11 @@ add_action('admin_menu', 'aicp_add_settings_page');
  */
 function aicp_register_general_settings() {
     register_setting('aicp_settings_group', 'aicp_settings', 'aicp_general_settings_sanitize');
-    register_setting('aicp_settings_group', 'aicp_assistant_templates', 'aicp_assistant_templates_sanitize');
-    add_settings_section('aicp_api_key_section', __('Ajustes de la API de OpenAI', 'ai-chatbot-pro'), null, 'aicp-settings');
-    add_settings_field('aicp_api_key', __('API Key', 'ai-chatbot-pro'), 'aicp_api_key_field_render', 'aicp-settings', 'aicp_api_key_section');
-    add_settings_section('aicp_templates_section', __('Plantillas del asistente', 'ai-chatbot-pro'), 'aicp_templates_section_render', 'aicp-settings');
-    add_settings_field('aicp_template_editor', __('Plantillas disponibles', 'ai-chatbot-pro'), 'aicp_template_editor_field_render', 'aicp-settings', 'aicp_templates_section');
+    register_setting('aicp_settings_group', 'aicp_model_providers', 'aicp_model_providers_sanitize');
+    add_settings_section('aicp_provider_section', __('Modelos y Proveedores', 'ai-chatbot-pro'), null, 'aicp-settings');
+    add_settings_field('aicp_provider_openai', __('OpenAI / ChatGPT', 'ai-chatbot-pro'), 'aicp_provider_openai_render', 'aicp-settings', 'aicp_provider_section');
+    add_settings_field('aicp_provider_gemini', __('Google Gemini', 'ai-chatbot-pro'), 'aicp_provider_gemini_render', 'aicp-settings', 'aicp_provider_section');
+    add_settings_field('aicp_provider_custom', __('Otros proveedores', 'ai-chatbot-pro'), 'aicp_provider_custom_render', 'aicp-settings', 'aicp_provider_section');
     do_action('aicp_after_settings_fields');
 }
 add_action('admin_init', 'aicp_register_general_settings');
@@ -39,10 +39,67 @@ add_action('admin_init', 'aicp_register_general_settings');
 /**
  * Renderiza el campo de la API Key.
  */
-function aicp_api_key_field_render() {
-    $options = get_option('aicp_settings');
-    $api_key = isset($options['api_key']) ? esc_attr($options['api_key']) : '';
-    echo '<input type="password" name="aicp_settings[api_key]" value="' . $api_key . '" class="regular-text" placeholder="' . __('Introduce tu clave API aquí', 'ai-chatbot-pro') . '">';
+function aicp_provider_openai_render() {
+    if (!class_exists('AICP_Crypto_Helper')) {
+        require_once AICP_PLUGIN_DIR . 'includes/class-crypto-helper.php';
+    }
+    $settings = get_option('aicp_model_providers', []);
+    $config   = $settings['openai'] ?? [];
+    $api_key  = isset($config['api_key']) ? AICP_Crypto_Helper::decrypt($config['api_key']) : '';
+    $model    = esc_attr($config['model'] ?? 'gpt-4o-mini');
+    $base_url = esc_url($config['base_url'] ?? '');
+    ?>
+    <p><label for="aicp_openai_api_key"><?php _e('API Key', 'ai-chatbot-pro'); ?></label><br>
+    <input type="password" name="aicp_model_providers[openai][api_key]" id="aicp_openai_api_key" value="<?php echo esc_attr($api_key); ?>" class="regular-text" placeholder="sk-..." /></p>
+    <p><label for="aicp_openai_model"><?php _e('Modelo', 'ai-chatbot-pro'); ?></label><br>
+    <input type="text" name="aicp_model_providers[openai][model]" id="aicp_openai_model" value="<?php echo $model; ?>" class="regular-text" placeholder="gpt-4o" /></p>
+    <p><label for="aicp_openai_base_url"><?php _e('URL alternativa', 'ai-chatbot-pro'); ?></label><br>
+    <input type="url" name="aicp_model_providers[openai][base_url]" id="aicp_openai_base_url" value="<?php echo $base_url; ?>" class="regular-text" placeholder="https://tu-proxy/v1/chat/completions" /></p>
+    <?php
+}
+
+function aicp_provider_gemini_render() {
+    if (!class_exists('AICP_Crypto_Helper')) {
+        require_once AICP_PLUGIN_DIR . 'includes/class-crypto-helper.php';
+    }
+    $settings = get_option('aicp_model_providers', []);
+    $config   = $settings['gemini'] ?? [];
+    $api_key  = isset($config['api_key']) ? AICP_Crypto_Helper::decrypt($config['api_key']) : '';
+    $model    = esc_attr($config['model'] ?? '');
+    $endpoint = esc_url($config['endpoint'] ?? '');
+    ?>
+    <p><label for="aicp_gemini_api_key"><?php _e('API Key', 'ai-chatbot-pro'); ?></label><br>
+    <input type="password" name="aicp_model_providers[gemini][api_key]" id="aicp_gemini_api_key" value="<?php echo esc_attr($api_key); ?>" class="regular-text" /></p>
+    <p><label for="aicp_gemini_model"><?php _e('Modelo', 'ai-chatbot-pro'); ?></label><br>
+    <input type="text" name="aicp_model_providers[gemini][model]" id="aicp_gemini_model" value="<?php echo $model; ?>" class="regular-text" placeholder="gemini-1.5-pro" /></p>
+    <p><label for="aicp_gemini_endpoint"><?php _e('Ruta de endpoint', 'ai-chatbot-pro'); ?></label><br>
+    <input type="url" name="aicp_model_providers[gemini][endpoint]" id="aicp_gemini_endpoint" value="<?php echo $endpoint; ?>" class="regular-text" placeholder="https://generativelanguage.googleapis.com/v1beta/" /></p>
+    <?php
+}
+
+function aicp_provider_custom_render() {
+    if (!class_exists('AICP_Crypto_Helper')) {
+        require_once AICP_PLUGIN_DIR . 'includes/class-crypto-helper.php';
+    }
+    $settings   = get_option('aicp_model_providers', []);
+    $config     = $settings['custom'] ?? [];
+    $api_key    = isset($config['api_key']) ? AICP_Crypto_Helper::decrypt($config['api_key']) : '';
+    $model      = esc_attr($config['model'] ?? '');
+    $endpoint   = esc_url($config['endpoint'] ?? '');
+    $temperature = esc_attr($config['temperature'] ?? '');
+    $max_tokens  = esc_attr($config['max_tokens'] ?? '');
+    ?>
+    <p><label for="aicp_custom_api_key"><?php _e('API Key', 'ai-chatbot-pro'); ?></label><br>
+    <input type="password" name="aicp_model_providers[custom][api_key]" id="aicp_custom_api_key" value="<?php echo esc_attr($api_key); ?>" class="regular-text" /></p>
+    <p><label for="aicp_custom_endpoint"><?php _e('Endpoint', 'ai-chatbot-pro'); ?></label><br>
+    <input type="url" name="aicp_model_providers[custom][endpoint]" id="aicp_custom_endpoint" value="<?php echo $endpoint; ?>" class="regular-text" placeholder="https://mi-api.chat" /></p>
+    <p><label for="aicp_custom_model"><?php _e('Modelo', 'ai-chatbot-pro'); ?></label><br>
+    <input type="text" name="aicp_model_providers[custom][model]" id="aicp_custom_model" value="<?php echo $model; ?>" class="regular-text" /></p>
+    <p><label for="aicp_custom_temperature"><?php _e('Temperatura (opcional)', 'ai-chatbot-pro'); ?></label><br>
+    <input type="number" step="0.1" name="aicp_model_providers[custom][temperature]" id="aicp_custom_temperature" value="<?php echo $temperature; ?>" class="small-text" /></p>
+    <p><label for="aicp_custom_max_tokens"><?php _e('Máx. tokens (opcional)', 'ai-chatbot-pro'); ?></label><br>
+    <input type="number" name="aicp_model_providers[custom][max_tokens]" id="aicp_custom_max_tokens" value="<?php echo $max_tokens; ?>" class="small-text" /></p>
+    <?php
 }
 
 /**
@@ -76,37 +133,11 @@ function aicp_render_settings_page() {
     <?php
 }
 
-function aicp_templates_section_render() {
-    echo '<p>' . esc_html__('Edita las plantillas base que se utilizan al crear nuevos asistentes. Usa el formato JSON y asegúrate de mantener los identificadores únicos.', 'ai-chatbot-pro') . '</p>';
-}
-
-function aicp_template_editor_field_render() {
-    $stored_templates = get_option('aicp_assistant_templates');
-    if (!is_array($stored_templates) || empty($stored_templates)) {
-        if (function_exists('aicp_get_default_assistant_templates')) {
-            $stored_templates = aicp_get_default_assistant_templates();
-        } else {
-            $stored_templates = [];
-        }
-    }
-
-    $json = wp_json_encode($stored_templates, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
-    ?>
-    <textarea name="aicp_assistant_templates" rows="15" class="large-text code" spellcheck="false"><?php echo esc_textarea($json); ?></textarea>
-    <p class="description"><?php esc_html_e('Introduce un array de objetos con los campos id, label y system_prompt_template. Los datos se sanitizan automáticamente antes de guardarse.', 'ai-chatbot-pro'); ?></p>
-    <?php
-}
-
 /**
  * Sanitiza las opciones de ajustes generales.
  */
 function aicp_general_settings_sanitize($input) {
     $sanitized = [];
-
-    // Guarda los ajustes del plugin principal
-    if (isset($input['api_key'])) {
-        $sanitized['api_key'] = sanitize_text_field($input['api_key']);
-    }
 
     // Si el addon PRO está activo, le pasa los datos para que guarde los suyos.
     if (class_exists('AICP_Pro_Features')) {
@@ -116,37 +147,29 @@ function aicp_general_settings_sanitize($input) {
     return $sanitized;
 }
 
-function aicp_assistant_templates_sanitize($input) {
-    $raw = $input;
-
-    if (is_string($raw)) {
-        $raw = wp_unslash($raw);
-        $decoded = json_decode($raw, true);
-    } elseif (is_array($raw)) {
-        $decoded = $raw;
-    } else {
-        $decoded = [];
+function aicp_model_providers_sanitize($input) {
+    if (!class_exists('AICP_Crypto_Helper')) {
+        require_once AICP_PLUGIN_DIR . 'includes/class-crypto-helper.php';
     }
-
-    if (!is_array($decoded)) {
-        add_settings_error('aicp_assistant_templates', 'aicp_templates_invalid_json', __('El JSON proporcionado no es válido.', 'ai-chatbot-pro'));
-        return get_option('aicp_assistant_templates', []);
-    }
-
-    if (!function_exists('aicp_sanitize_assistant_templates_array')) {
-        require_once AICP_PLUGIN_DIR . 'includes/template-functions.php';
-    }
-
-    $sanitized = aicp_sanitize_assistant_templates_array($decoded);
-
-    if (empty($sanitized)) {
-        add_settings_error('aicp_assistant_templates', 'aicp_templates_empty', __('No se pudo guardar ninguna plantilla válida. Revisa el formato y los campos obligatorios.', 'ai-chatbot-pro'));
-        return get_option('aicp_assistant_templates', []);
-    }
-
-    if (function_exists('aicp_clear_assistant_templates_cache')) {
-        aicp_clear_assistant_templates_cache();
-    }
+    $sanitized = [
+        'openai' => [
+            'api_key' => isset($input['openai']['api_key']) ? AICP_Crypto_Helper::encrypt(sanitize_text_field($input['openai']['api_key'])) : '',
+            'model'   => isset($input['openai']['model']) ? sanitize_text_field($input['openai']['model']) : '',
+            'base_url'=> isset($input['openai']['base_url']) ? esc_url_raw($input['openai']['base_url']) : '',
+        ],
+        'gemini' => [
+            'api_key'  => isset($input['gemini']['api_key']) ? AICP_Crypto_Helper::encrypt(sanitize_text_field($input['gemini']['api_key'])) : '',
+            'model'    => isset($input['gemini']['model']) ? sanitize_text_field($input['gemini']['model']) : '',
+            'endpoint' => isset($input['gemini']['endpoint']) ? esc_url_raw($input['gemini']['endpoint']) : '',
+        ],
+        'custom' => [
+            'api_key'     => isset($input['custom']['api_key']) ? AICP_Crypto_Helper::encrypt(sanitize_text_field($input['custom']['api_key'])) : '',
+            'endpoint'    => isset($input['custom']['endpoint']) ? esc_url_raw($input['custom']['endpoint']) : '',
+            'model'       => isset($input['custom']['model']) ? sanitize_text_field($input['custom']['model']) : '',
+            'temperature' => isset($input['custom']['temperature']) ? floatval($input['custom']['temperature']) : '',
+            'max_tokens'  => isset($input['custom']['max_tokens']) ? intval($input['custom']['max_tokens']) : '',
+        ],
+    ];
 
     return $sanitized;
 }

--- a/ai-chatbot-pro/assets/css/chatbot.css
+++ b/ai-chatbot-pro/assets/css/chatbot.css
@@ -59,7 +59,15 @@
     object-fit: cover;
     background-color: white;
 }
-.aicp-message-bubble { padding: 8px 14px; border-radius: 18px; line-height: 1.45; word-wrap: break-word; position: relative; }
+.aicp-message-bubble {
+    padding: 8px 14px;
+    border-radius: 18px;
+    line-height: 1.45;
+    word-wrap: break-word;
+    position: relative;
+    max-height: 340px;
+    overflow-y: auto;
+}
 
 .aicp-chat-message.bot { align-self: flex-start; }
 .aicp-chat-message.bot .aicp-message-bubble { background: var(--aicp-color-bot-bg); color: var(--aicp-color-bot-text); border-bottom-left-radius: 4px; }

--- a/ai-chatbot-pro/assets/js/chatbot.js
+++ b/ai-chatbot-pro/assets/js/chatbot.js
@@ -397,47 +397,108 @@ function renderQuickReplies() {
         }, delay * 1000);
     }
 
-    function addMessageToChat(role, text, isCalendarMessage = false) {
+    function renderTextWithLineBreaks($container, text) {
+        const safeText = typeof text === 'string' ? text : '';
+        const parts = safeText.split(/\n/);
+        $container.empty();
+        parts.forEach((part, index) => {
+            $container.append(document.createTextNode(part));
+            if (index < parts.length - 1) {
+                $container.append('<br>');
+            }
+        });
+    }
+
+    function smoothScrollToMessage($msg) {
+        const $chatBody = $('.aicp-chat-body');
+        if (!$chatBody.length) return;
+        const target = $msg.position() ? $msg.position().top + $chatBody.scrollTop() : $chatBody[0].scrollHeight;
+        $chatBody.stop().animate({ scrollTop: target }, 200);
+    }
+
+    function chunkTextForStream(text, size = 28) {
+        const safeText = typeof text === 'string' ? text : String(text ?? '');
+        const chunks = [];
+        for (let i = 0; i < safeText.length; i += size) {
+            chunks.push(safeText.slice(i, i + size));
+        }
+        return chunks.length ? chunks : [''];
+    }
+
+    function addMessageToChat(role, text, options = {}) {
+        const { stream = false, isCalendarMessage = false } = options;
         // --- INICIO: Logging ---
-        console.log(`[AICP Debug] Adding message to chat: Role=${role}, Calendar=${isCalendarMessage}, Text=`, text);
+        console.log(`[AICP Debug] Adding message to chat: Role=${role}, Calendar=${isCalendarMessage}, Stream=${stream}, Text=`, text);
         // --- FIN: Logging ---
         resetInactivityTimer();
         const $chatBody = $('.aicp-chat-body');
         const messageText = text == null ? '' : String(text); // Asegurar que sea string
-        let sanitizedText = $('<div/>').text(messageText).html().replace(/\n/g, '<br>');
-
-        if (isCalendarMessage && params.calendar_url) {
-            sanitizedText += `<br><br><a href="${params.calendar_url}" class="aicp-calendar-link" data-log-id="${logId}" data-assistant-id="${params.assistant_id}" data-calendar-nonce="${params.calendar_nonce}" target="_blank">📅 Reservar cita</a>`;
-        }
-
         const avatarSrc = (role === 'bot') ? params.bot_avatar : params.user_avatar;
 
-        const feedbackButtons = (role === 'bot' && params.enable_feedback) ? `
-        <div class="aicp-feedback-buttons">
-            <button class="aicp-feedback-btn" data-feedback="1" aria-label="Me gusta">...</button>
-            <button class="aicp-feedback-btn" data-feedback="-1" aria-label="No me gusta">...</button>
-        </div>` : '';
-
-        const messageHTML = `
+        const $msg = $(`
         <div class="aicp-chat-message ${role}">
             <div class="aicp-message-avatar">
                 <img src="${avatarSrc}" alt="Avatar de ${role}">
             </div>
             <div class="aicp-message-bubble">
-                ${sanitizedText}
-                ${feedbackButtons}
+                <div class="aicp-message-text"></div>
             </div>
-        </div>`;
+        </div>`);
 
-        const $msg = $(messageHTML);
+        const $textContainer = $msg.find('.aicp-message-text');
+        const feedbackButtons = (role === 'bot' && params.enable_feedback) ? `
+            <div class="aicp-feedback-buttons">
+                <button class="aicp-feedback-btn" data-feedback="1" aria-label="Me gusta">...</button>
+                <button class="aicp-feedback-btn" data-feedback="-1" aria-label="No me gusta">...</button>
+            </div>` : '';
+
         $chatBody.append($msg);
-        scrollToMessage($msg); // Intentar hacer scroll siempre
+        smoothScrollToMessage($msg);
 
-        if (isFarewell(text)) {
-            // --- INICIO: Logging ---
-            console.log('[AICP Debug] Farewell detected, scheduling finalizeChat.');
-            // --- FIN: Logging ---
-            setTimeout(finalizeChat, 1000);
+        if (stream) {
+            const chunks = chunkTextForStream(messageText);
+            let accumulated = '';
+            const appendCalendarLink = () => {
+                if (isCalendarMessage && params.calendar_url) {
+                    const $link = $(`<br><br><a href="${params.calendar_url}" class="aicp-calendar-link" data-log-id="${logId}" data-assistant-id="${params.assistant_id}" data-calendar-nonce="${params.calendar_nonce}" target="_blank">📅 Reservar cita</a>`);
+                    $textContainer.append($link);
+                }
+                if (feedbackButtons) {
+                    $msg.find('.aicp-message-bubble').append(feedbackButtons);
+                }
+            };
+
+            const streamNextChunk = (index = 0) => {
+                accumulated += chunks[index];
+                renderTextWithLineBreaks($textContainer, accumulated);
+                smoothScrollToMessage($msg);
+                if (index < chunks.length - 1) {
+                    setTimeout(() => streamNextChunk(index + 1), 55);
+                } else {
+                    appendCalendarLink();
+                    if (isFarewell(messageText)) {
+                        setTimeout(finalizeChat, 1000);
+                    }
+                }
+            };
+
+            streamNextChunk();
+        } else {
+            renderTextWithLineBreaks($textContainer, messageText);
+            if (isCalendarMessage && params.calendar_url) {
+                const $link = $(`<br><br><a href="${params.calendar_url}" class="aicp-calendar-link" data-log-id="${logId}" data-assistant-id="${params.assistant_id}" data-calendar-nonce="${params.calendar_nonce}" target="_blank">📅 Reservar cita</a>`);
+                $textContainer.append($link);
+            }
+            if (feedbackButtons) {
+                $msg.find('.aicp-message-bubble').append(feedbackButtons);
+            }
+            smoothScrollToMessage($msg);
+            if (isFarewell(text)) {
+                // --- INICIO: Logging ---
+                console.log('[AICP Debug] Farewell detected, scheduling finalizeChat.');
+                // --- FIN: Logging ---
+                setTimeout(finalizeChat, 1000);
+            }
         }
     }
 
@@ -523,22 +584,7 @@ function renderQuickReplies() {
     }
 
     function scrollToMessage($msg) {
-        const $chatBody = $('.aicp-chat-body');
-        // Usar scrollTop nativo que es más fiable
-        // Calcular la posición relativa al contenedor y sumar el scroll actual
-        try {
-             const msgTopRelativeToContainer = $msg.position().top;
-             const currentScrollTop = $chatBody.scrollTop();
-             const newScrollTop = currentScrollTop + msgTopRelativeToContainer - 10; // Pequeño offset
-             $chatBody.scrollTop(newScrollTop);
-             // --- INICIO: Logging ---
-             // console.log(`[AICP Debug] Scrolling to message. New scrollTop: ${newScrollTop}`);
-             // --- FIN: Logging ---
-        } catch(e) {
-             console.error("[AICP Debug] Error calculating scroll position:", e);
-             // Fallback: scroll al fondo
-             $chatBody.scrollTop($chatBody[0].scrollHeight);
-        }
+        smoothScrollToMessage($msg);
     }
 
 
@@ -644,11 +690,9 @@ function renderQuickReplies() {
 
                     // Validar que botReply sea string antes de procesar
                     if (typeof botReply === 'string') {
-                         const parts = splitLongMessage(botReply, 170);
-                         parts.forEach(part => {
-                             conversationHistory.push({ role: 'assistant', content: part });
-                             addMessageToChat('bot', part);
-                         });
+                         conversationHistory.push({ role: 'assistant', content: botReply });
+                         const isCalendarMessage = parsedResponse.data.lead_status === 'calendar';
+                         addMessageToChat('bot', botReply, { stream: true, isCalendarMessage });
                     } else {
                          // --- INICIO: Logging ---
                          console.error('[AICP Debug] Invalid reply format received from server:', botReply);

--- a/ai-chatbot-pro/includes/class-ajax-handler.php
+++ b/ai-chatbot-pro/includes/class-ajax-handler.php
@@ -465,14 +465,11 @@ class AICP_Ajax_Handler {
         // Decidir si usar webhook
         $use_webhook = !empty($assistant_settings['forward_to_webhook']) && !empty($assistant_settings['forward_webhook_url']);
 
-        // Calcular system_prompt
-        $system_prompt = '';
+        // Calcular prompt maestro
         if (!class_exists('AICP_Prompt_Builder') && defined('AICP_PLUGIN_DIR') && file_exists(AICP_PLUGIN_DIR . 'includes/class-prompt-builder.php')) {
             require_once AICP_PLUGIN_DIR . 'includes/class-prompt-builder.php';
         }
-        if (class_exists('AICP_Prompt_Builder')) {
-            $system_prompt = AICP_Prompt_Builder::build($assistant_settings, $page_context);
-        } else { $system_prompt = 'Eres un asistente.'; } // Fallback muy básico
+        $system_prompt = class_exists('AICP_Prompt_Builder') ? AICP_Prompt_Builder::build($assistant_settings, $page_context) : 'Eres un asistente.';
 
         // Conversación para API/Webhook
         $full_conversation_for_api = [];
@@ -490,39 +487,29 @@ class AICP_Ajax_Handler {
             $reply = $webhook_result['reply'];
             $metadata = $webhook_result['metadata'] ?? [];
         } else {
-            // Lógica API OpenAI Chat Completions (versión base)
-            $api_key = $global_settings['api_key'] ?? '';
-            if (empty($api_key)) {
-                wp_send_json_error(['message' => __('La API Key de OpenAI no está configurada.', 'ai-chatbot-pro')]); return;
+            if (!class_exists('AICP_Model_Router')) {
+                require_once AICP_PLUGIN_DIR . 'includes/class-model-router.php';
             }
-            $api_url = 'https://api.openai.com/v1/chat/completions';
-            $model = $assistant_settings['model'] ?? null;
-            if (!defined('AICP_AVAILABLE_MODELS')) {
-                 $model_list_path = AICP_PLUGIN_DIR . 'includes/model-list.php';
-                 if (file_exists($model_list_path)) require_once $model_list_path;
-            }
-            if (!defined('AICP_AVAILABLE_MODELS') || !isset(AICP_AVAILABLE_MODELS[$model])) {
-                 $model = defined('AICP_AVAILABLE_MODELS') ? array_key_first(AICP_AVAILABLE_MODELS) : 'gpt-4o-mini';
+            if (!class_exists('AICP_Crypto_Helper')) {
+                require_once AICP_PLUGIN_DIR . 'includes/class-crypto-helper.php';
             }
 
-            $api_args = [
-                'method' => 'POST', 'headers' => ['Content-Type' => 'application/json', 'Authorization' => 'Bearer ' . $api_key],
-                'body' => wp_json_encode(['model' => $model, 'messages' => $full_conversation_for_api]),
-                'timeout' => 60,
-            ];
-            $api_response = wp_remote_post($api_url, $api_args);
+            $providers = get_option('aicp_model_providers', []);
+            $provider_key = $assistant_settings['provider'] ?? 'openai';
+            $provider_settings = $providers[$provider_key] ?? [];
 
-            if (is_wp_error($api_response)) {
-                wp_send_json_error(['message' => $api_response->get_error_message()]); return;
+            if (!empty($provider_settings['api_key'])) {
+                $provider_settings['api_key'] = AICP_Crypto_Helper::decrypt($provider_settings['api_key']);
             }
-            $body = json_decode(wp_remote_retrieve_body($api_response), true);
-            if (isset($body['choices'][0]['message']['content'])) {
-                $reply = trim($body['choices'][0]['message']['content']);
-            } else {
-                $error_message = $body['error']['message'] ?? __('Respuesta inesperada de OpenAI.', 'ai-chatbot-pro');
-                error_log("AICP OpenAI Error: " . $error_message . " | Body: " . wp_remote_retrieve_body($api_response));
-                wp_send_json_error(['message' => $error_message]); return;
+
+            $driver = AICP_Model_Router::get_driver($provider_key);
+            $driver_result = $driver->send_message($system_prompt, $history, $provider_settings);
+
+            if (is_wp_error($driver_result)) {
+                wp_send_json_error(['message' => $driver_result->get_error_message()]); return;
             }
+
+            $reply = $driver_result;
         }
         // --- FIN LÓGICA WEBHOOK o API ---
 

--- a/ai-chatbot-pro/includes/class-crypto-helper.php
+++ b/ai-chatbot-pro/includes/class-crypto-helper.php
@@ -1,0 +1,27 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+class AICP_Crypto_Helper {
+    protected static function get_key() {
+        $secret = wp_salt('auth');
+        return hash('sha256', $secret, true);
+    }
+
+    protected static function get_iv() {
+        return substr(hash('sha256', wp_salt('secure_auth')), 0, 16);
+    }
+
+    public static function encrypt($value) {
+        if ($value === '') return '';
+        $encrypted = openssl_encrypt($value, 'AES-256-CBC', self::get_key(), 0, self::get_iv());
+        return base64_encode($encrypted);
+    }
+
+    public static function decrypt($value) {
+        if ($value === '') return '';
+        $decoded = base64_decode($value, true);
+        if ($decoded === false) return '';
+        $decrypted = openssl_decrypt($decoded, 'AES-256-CBC', self::get_key(), 0, self::get_iv());
+        return $decrypted === false ? '' : $decrypted;
+    }
+}

--- a/ai-chatbot-pro/includes/class-model-router.php
+++ b/ai-chatbot-pro/includes/class-model-router.php
@@ -1,0 +1,19 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+class AICP_Model_Router {
+    public static function get_driver($provider) {
+        switch ($provider) {
+            case 'gemini':
+                require_once AICP_PLUGIN_DIR . 'includes/providers/class-gemini-driver.php';
+                return new AICP_Gemini_Driver();
+            case 'custom':
+                require_once AICP_PLUGIN_DIR . 'includes/providers/class-generic-driver.php';
+                return new AICP_Generic_Driver();
+            case 'openai':
+            default:
+                require_once AICP_PLUGIN_DIR . 'includes/providers/class-openai-driver.php';
+                return new AICP_OpenAI_Driver();
+        }
+    }
+}

--- a/ai-chatbot-pro/includes/class-prompt-builder.php
+++ b/ai-chatbot-pro/includes/class-prompt-builder.php
@@ -27,91 +27,14 @@ class AICP_Prompt_Builder {
     }
 
     public static function build($settings, $page_context = '') {
-        $forwarding_enabled = !empty($settings['forward_to_webhook']);
-        $behavior_rules     = isset($settings['behavior_rules']) ? trim($settings['behavior_rules']) : '';
-        $append_behavior    = !$forwarding_enabled && $behavior_rules !== '';
-
-        $prompt = '';
-
-        if (isset($settings['custom_prompt']) && !empty($settings['use_custom_prompt'])) {
-            $prompt = $settings['custom_prompt'];
-        } else {
-            $parts = [];
-            $template_id = $settings['template_id'] ?? '';
-
-            if ($template_id) {
-                $template = self::get_template($template_id);
-                if ($template && !empty($template['system_prompt_template'])) {
-                    $meta = [
-                        'brand'          => function_exists('get_option') ? get_option('aicp_brand', '') : '',
-                        'domain'         => function_exists('get_option') ? get_option('aicp_domain', '') : '',
-                        'services'       => function_exists('get_option') ? implode(', ', (array) get_option('aicp_services', [])) : '',
-                        'pricing_ranges' => function_exists('get_option') ? (array) get_option('aicp_pricing_ranges', []) : [],
-                        'timezone'       => function_exists('wp_timezone_string') ? wp_timezone_string() : 'UTC',
-                    ];
-
-                    foreach ($meta['pricing_ranges'] as $key => $value) {
-                        $meta['pricing_ranges.' . $key] = $value;
-                    }
-
-                    if (function_exists('aicp_render_template')) {
-                        $parts[] = aicp_render_template($template['system_prompt_template'], $meta);
-                    } else {
-                        $parts[] = $template['system_prompt_template'];
-                    }
-                }
-            }
-
-            if (!empty($settings['persona'])) {
-                $parts[] = 'PERSONALIDAD: ' . $settings['persona'];
-            }
-            if (!empty($settings['objective'])) {
-                $parts[] = 'OBJETIVO PRINCIPAL: ' . $settings['objective'];
-            }
-            if (!empty($settings['length_tone'])) {
-                $parts[] = 'TONO Y LONGITUD: ' . $settings['length_tone'];
-            }
-            if (!empty($settings['example'])) {
-                $parts[] = 'EJEMPLO DE RESPUESTA: ' . $settings['example'];
-            }
-
-            if (!empty($settings['lead_fields']) && is_array($settings['lead_fields'])) {
-                $fields_desc = [];
-                foreach ($settings['lead_fields'] as $field) {
-                    $required = !empty($field['required']) ? '(Obligatorio)' : '(Opcional)';
-                    $label    = $field['label'] ?? ($field['name'] ?? '');
-                    if ($label === '') {
-                        continue;
-                    }
-                    $fields_desc[] = "- {$label} {$required}";
-                }
-
-                if (!empty($fields_desc)) {
-                    $parts[] = "INSTRUCCIÓN DE CAPTURA DE DATOS:\nDebes obtener la siguiente información del usuario de manera natural durante la conversación:\n"
-                        . implode("\n", $fields_desc)
-                        . "\n\nCuando obtengas estos datos, el sistema los detectará automáticamente. No menciones 'JSON' ni códigos internos al usuario, solo pide los datos.";
-                }
-            }
-
-            if (!empty($page_context)) {
-                $parts[] = "--- INICIO DEL CONTEXTO DE LA PÁGINA ACTUAL ---\n" . $page_context . "\n--- FIN DEL CONTEXTO ---";
-                $parts[] = 'Responde a las preguntas del usuario basándote en el contexto de la página proporcionado. Si la información no está en el contexto, indícalo amablemente.';
-            }
-
-            $prompt = implode("\n\n", $parts);
+        if (!empty($settings['master_prompt'])) {
+            return trim(wp_kses_post($settings['master_prompt']));
         }
 
-        $prompt = trim($prompt);
-
-        if ($append_behavior) {
-            $behavior_block = "== REGLAS DE COMPORTAMIENTO (Filtro Adicional) ==\n" . $behavior_rules;
-            $prompt = $prompt === '' ? $behavior_block : $prompt . "\n\n" . $behavior_block;
+        if (!empty($page_context)) {
+            return trim("--- CONTEXTO ---\n" . $page_context);
         }
 
-        if ($prompt === '') {
-            $prompt = 'Eres un asistente de IA.';
-        }
-
-        return $prompt;
+        return 'Eres un asistente de IA.';
     }
 }

--- a/ai-chatbot-pro/includes/providers/class-gemini-driver.php
+++ b/ai-chatbot-pro/includes/providers/class-gemini-driver.php
@@ -1,0 +1,49 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+if (!interface_exists('AICP_Model_Driver_Interface')) {
+    require_once __DIR__ . '/class-model-driver.php';
+}
+
+class AICP_Gemini_Driver implements AICP_Model_Driver_Interface {
+    public function send_message($prompt, $history, $settings) {
+        $api_key = $settings['api_key'] ?? '';
+        $model   = $settings['model'] ?? '';
+        $endpoint = $settings['endpoint'] ?? '';
+
+        if ($api_key === '' || $model === '' || $endpoint === '') {
+            return new WP_Error('aicp_missing_gemini_config', __('Configura la API Key, modelo y endpoint de Gemini.', 'ai-chatbot-pro'));
+        }
+
+        $messages = [];
+        if (!empty($prompt)) {
+            $messages[] = ['role' => 'user', 'parts' => [['text' => $prompt]]];
+        }
+        foreach ($history as $message) {
+            if (!isset($message['role'], $message['content'])) continue;
+            $messages[] = [
+                'role'  => $message['role'] === 'assistant' ? 'model' : 'user',
+                'parts' => [['text' => wp_kses_post($message['content'])]],
+            ];
+        }
+
+        $payload = [
+            'contents' => $messages,
+        ];
+
+        $url = trailingslashit($endpoint) . 'models/' . rawurlencode($model) . ':generateContent?key=' . rawurlencode($api_key);
+        $response = wp_remote_post($url, [
+            'timeout' => 60,
+            'headers' => ['Content-Type' => 'application/json'],
+            'body'    => wp_json_encode($payload),
+        ]);
+
+        if (is_wp_error($response)) return $response;
+        $body = json_decode(wp_remote_retrieve_body($response), true);
+        if (isset($body['candidates'][0]['content']['parts'][0]['text'])) {
+            return trim($body['candidates'][0]['content']['parts'][0]['text']);
+        }
+
+        return new WP_Error('aicp_gemini_invalid', __('Respuesta inesperada del modelo Gemini.', 'ai-chatbot-pro'));
+    }
+}

--- a/ai-chatbot-pro/includes/providers/class-generic-driver.php
+++ b/ai-chatbot-pro/includes/providers/class-generic-driver.php
@@ -1,0 +1,55 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+if (!interface_exists('AICP_Model_Driver_Interface')) {
+    require_once __DIR__ . '/class-model-driver.php';
+}
+
+class AICP_Generic_Driver implements AICP_Model_Driver_Interface {
+    public function send_message($prompt, $history, $settings) {
+        $api_key  = $settings['api_key'] ?? '';
+        $endpoint = $settings['endpoint'] ?? '';
+        $model    = $settings['model'] ?? '';
+        $temperature = isset($settings['temperature']) ? floatval($settings['temperature']) : null;
+        $max_tokens  = isset($settings['max_tokens']) ? intval($settings['max_tokens']) : null;
+
+        if ($endpoint === '' || $model === '') {
+            return new WP_Error('aicp_generic_missing', __('El endpoint y modelo personalizados son obligatorios.', 'ai-chatbot-pro'));
+        }
+
+        $payload = [
+            'model'    => $model,
+            'prompt'   => $prompt,
+            'messages' => $history,
+        ];
+        if ($temperature !== null) {
+            $payload['temperature'] = $temperature;
+        }
+        if ($max_tokens !== null && $max_tokens > 0) {
+            $payload['max_tokens'] = $max_tokens;
+        }
+
+        $headers = ['Content-Type' => 'application/json'];
+        if ($api_key !== '') {
+            $headers['Authorization'] = 'Bearer ' . $api_key;
+        }
+
+        $response = wp_remote_post($endpoint, [
+            'timeout' => 60,
+            'headers' => $headers,
+            'body'    => wp_json_encode($payload),
+        ]);
+
+        if (is_wp_error($response)) return $response;
+        $body = json_decode(wp_remote_retrieve_body($response), true);
+
+        if (isset($body['reply'])) {
+            return wp_kses_post($body['reply']);
+        }
+        if (isset($body['choices'][0]['message']['content'])) {
+            return wp_kses_post($body['choices'][0]['message']['content']);
+        }
+
+        return new WP_Error('aicp_generic_invalid', __('No se pudo interpretar la respuesta del proveedor.', 'ai-chatbot-pro'));
+    }
+}

--- a/ai-chatbot-pro/includes/providers/class-model-driver.php
+++ b/ai-chatbot-pro/includes/providers/class-model-driver.php
@@ -1,0 +1,6 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+interface AICP_Model_Driver_Interface {
+    public function send_message($prompt, $history, $settings);
+}

--- a/ai-chatbot-pro/includes/providers/class-openai-driver.php
+++ b/ai-chatbot-pro/includes/providers/class-openai-driver.php
@@ -1,0 +1,55 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+if (!interface_exists('AICP_Model_Driver_Interface')) {
+    require_once __DIR__ . '/class-model-driver.php';
+}
+
+class AICP_OpenAI_Driver implements AICP_Model_Driver_Interface {
+    public function send_message($prompt, $history, $settings) {
+        $api_key = $settings['api_key'] ?? '';
+        if (empty($api_key)) {
+            return new WP_Error('aicp_missing_api_key', __('Falta la API Key de OpenAI.', 'ai-chatbot-pro'));
+        }
+
+        $model = $settings['model'] ?? 'gpt-4o-mini';
+        $url   = !empty($settings['base_url']) ? $settings['base_url'] : 'https://api.openai.com/v1/chat/completions';
+
+        $messages = [];
+        if (!empty($prompt)) {
+            $messages[] = ['role' => 'system', 'content' => $prompt];
+        }
+        foreach ($history as $message) {
+            if (!isset($message['role'], $message['content'])) continue;
+            $messages[] = [
+                'role'    => sanitize_text_field($message['role']),
+                'content' => wp_kses_post($message['content']),
+            ];
+        }
+
+        $payload = [
+            'model'    => $model,
+            'messages' => $messages,
+        ];
+
+        $response = wp_remote_post($url, [
+            'timeout' => 60,
+            'headers' => [
+                'Authorization' => 'Bearer ' . $api_key,
+                'Content-Type'  => 'application/json',
+            ],
+            'body'    => wp_json_encode($payload),
+        ]);
+
+        if (is_wp_error($response)) {
+            return $response;
+        }
+
+        $body = json_decode(wp_remote_retrieve_body($response), true);
+        if (!isset($body['choices'][0]['message']['content'])) {
+            return new WP_Error('aicp_openai_invalid', __('Respuesta inesperada del modelo OpenAI.', 'ai-chatbot-pro'));
+        }
+
+        return trim($body['choices'][0]['message']['content']);
+    }
+}


### PR DESCRIPTION
## Summary
- add encrypted multi-provider settings for OpenAI, Gemini, and custom drivers with dedicated driver classes
- simplify assistant instructions to a single master prompt and provider selector while keeping lead history intact
- route chat requests through the driver abstraction using decrypted credentials

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921e7e46148833083c6e8fb7975d7ab)