### PR TITLE
Improve admin tabs and layout

### DIFF
--- a/ai-chatbot-pro/admin/assistant-meta-boxes.php
+++ b/ai-chatbot-pro/admin/assistant-meta-boxes.php
@@ -182,7 +182,7 @@ function aicp_render_main_meta_box($post) {
         $pro_tab_classes .= ' aicp-pro-tab--locked';
     }
     ?>
-    <div id="aicp-tab-instructions" class="aicp-tab-content">
+    <div id="aicp-tab-instructions" class="aicp-tab-content is-active">
         <?php aicp_render_instructions_tab($v); ?>
     </div>
     <div id="aicp-tab-design" class="aicp-tab-content">
@@ -367,6 +367,8 @@ function aicp_render_integrations_tab($assistant_id, $v) {
 }
 
 function aicp_render_leads_tab($assistant_id, $v) {
+    global $wpdb;
+
     $logs_table = $wpdb->prefix . 'aicp_chat_logs';
 
     echo '<p>' . __('El historial muestra las conversaciones y los datos estructurados capturados automáticamente. Los ajustes de leads se simplifican a los datos detectados dentro de cada conversación.', 'ai-chatbot-pro') . '</p>';

--- a/ai-chatbot-pro/assets/css/admin.css
+++ b/ai-chatbot-pro/assets/css/admin.css
@@ -4,7 +4,13 @@
 
 /* Pestañas */
 .aicp-nav-tab-wrapper { margin-bottom: -1px; }
-.aicp-tab-content { margin-top: 1em; }
+.aicp-tab-content {
+    margin-top: 1em;
+    display: none;
+}
+.aicp-tab-content.is-active {
+    display: block;
+}
 .aicp-pro-tag {
     display: inline-block; background-color: #ffba00; color: #000;
     font-size: 9px; font-weight: bold; padding: 2px 6px;

--- a/ai-chatbot-pro/assets/js/admin-scripts.js
+++ b/ai-chatbot-pro/assets/js/admin-scripts.js
@@ -92,7 +92,33 @@ jQuery(function($) {
     });
 
     function handleTabs() {
-        $('.aicp-nav-tab-wrapper a').on('click', function(e) {
+        const $navTabs = $('.aicp-nav-tab-wrapper a');
+        const $panels = $('.aicp-tab-content');
+
+        function activateTab(target, skipHashUpdate = false) {
+            if (!target || !$panels.filter(target).length) {
+                return;
+            }
+
+            $navTabs.removeClass('nav-tab-active');
+            const $targetTab = $navTabs.filter(`[href="${target}"]`);
+            if ($targetTab.length) {
+                $targetTab.addClass('nav-tab-active');
+            }
+
+            $panels.removeClass('is-active').attr('aria-hidden', 'true');
+            $(target).addClass('is-active').attr('aria-hidden', 'false');
+
+            if (!skipHashUpdate) {
+                if (window.history && typeof window.history.replaceState === 'function') {
+                    window.history.replaceState(null, '', target);
+                } else {
+                    window.location.hash = target;
+                }
+            }
+        }
+
+        $navTabs.on('click', function(e) {
             const $tab = $(this);
             const isDisabled = $tab.attr('aria-disabled') === 'true' || $tab.data('tabDisabled') === 1;
             if (isDisabled) {
@@ -104,13 +130,23 @@ jQuery(function($) {
             }
 
             e.preventDefault();
-            $('.aicp-nav-tab-wrapper a').removeClass('nav-tab-active');
-            $tab.addClass('nav-tab-active');
-            $('.aicp-tab-content').hide();
-            const targetTab = $tab.attr('href');
-            $(targetTab).show();
+            activateTab($tab.attr('href'));
         });
-        $('.aicp-tab-content').not(':first').hide();
+
+        let initialTarget = '';
+        if (window.location.hash && $panels.filter(window.location.hash).length) {
+            initialTarget = window.location.hash;
+        } else if ($navTabs.length) {
+            initialTarget = $navTabs.first().attr('href') || '';
+        }
+
+        if (!initialTarget && $panels.length) {
+            initialTarget = `#${$panels.first().attr('id')}`;
+        }
+
+        if (initialTarget) {
+            activateTab(initialTarget, true);
+        }
     }
     
     function handleMediaUploader() {


### PR DESCRIPTION
## Summary
- hide inactive assistant tabs by default to avoid mixed layouts
- restore tab activation via URL hash handling and aria visibility updates
- mark the instructions tab active on load so the editor has a stable default state

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921f98b01788330965dab2d2b714d99)