### PR TITLE
Refactor assistant editor layout and add provider connection tests

### DIFF
--- a/ai-chatbot-pro/admin/assistant-meta-boxes.php
+++ b/ai-chatbot-pro/admin/assistant-meta-boxes.php
@@ -10,31 +10,6 @@ if (!defined('ABSPATH')) exit;
  * Añade los meta boxes a la pantalla de edición de asistentes.
  */
 function aicp_add_meta_boxes() {
-    add_action('edit_form_top', function($post) {
-        if ($post->post_type !== 'aicp_assistant') return;
-
-        $settings = get_post_meta($post->ID, '_aicp_assistant_settings', true);
-        $settings = is_array($settings) ? $settings : [];
-        $forwarding_active = !empty($settings['forward_to_webhook']) && !empty($settings['forward_webhook_url']);
-
-        $disabled_class = $forwarding_active ? ' aicp-nav-tab--disabled' : '';
-        $disabled_attr  = $forwarding_active ? ' aria-disabled="true" data-tab-disabled="1"' : '';
-
-        echo '<h2 class="nav-tab-wrapper aicp-nav-tab-wrapper">';
-        echo '<a href="#aicp-tab-instructions" class="nav-tab nav-tab-active' . $disabled_class . '" data-lockable-tab="1"' . $disabled_attr . '>' . __('Instrucciones', 'ai-chatbot-pro') . '</a>';
-        echo '<a href="#aicp-tab-design" class="nav-tab">' . __('Diseño', 'ai-chatbot-pro') . '</a>';
-        echo '<a href="#aicp-tab-leads" class="nav-tab' . $disabled_class . '" data-lockable-tab="1"' . $disabled_attr . '>' . __('Leads', 'ai-chatbot-pro') . '</a>';
-        echo '<a href="#aicp-tab-integrations" class="nav-tab">' . __('Integraciones', 'ai-chatbot-pro') . '</a>';
-
-        // Lógica corregida para mostrar la pestaña PRO o el mensaje de venta.
-        if (class_exists('AICP_Pro_Features')) {
-            echo '<a href="#aicp-tab-pro" class="nav-tab' . $disabled_class . '" data-lockable-tab="1"' . $disabled_attr . '>' . __('Funciones PRO', 'ai-chatbot-pro') . ' <span class="aicp-pro-tag">PRO</span></a>';
-        } else {
-             echo '<a href="#aicp-tab-pro-upsell" class="nav-tab' . $disabled_class . '" data-lockable-tab="1"' . $disabled_attr . '>' . __('Funciones PRO', 'ai-chatbot-pro') . ' <span class="aicp-pro-tag">PRO</span></a>';
-        }
-        echo '</h2>';
-    });
-
     add_meta_box('aicp_main_settings_meta_box', __('Configuración del Asistente', 'ai-chatbot-pro'), 'aicp_render_main_meta_box', 'aicp_assistant', 'normal', 'high');
     add_meta_box('aicp_shortcode_meta_box', __('Shortcode', 'ai-chatbot-pro'), 'aicp_render_shortcode_meta_box', 'aicp_assistant', 'side', 'high');
 }
@@ -116,6 +91,7 @@ function aicp_admin_scripts($hook) {
         'default_user_avatar' => $default_user_avatar,
         'default_open_icon' => $default_open_icon,
         'templates_url' => add_query_arg('action', 'aicp_get_templates', admin_url('admin-ajax.php')),
+        'template_description_fallback' => __('Selecciona una plantilla para precargar un prompt de sistema.', 'ai-chatbot-pro'),
         'lead_fields' => AICP_Lead_Manager::get_lead_field_config($post_id, $settings),
         'initial_settings' => [
             'bot_avatar_url' => $settings['bot_avatar_url'] ?? $default_bot_avatar,
@@ -128,12 +104,9 @@ function aicp_admin_scripts($hook) {
             'color_user_bg' => $settings['color_user_bg'] ?? '#dcf8c6',
             'color_user_text' => $settings['color_user_text'] ?? '#000000',
             'provider' => $settings['provider'] ?? 'openai',
+            'model' => $settings['model'] ?? '',
             'master_prompt' => $settings['master_prompt'] ?? '',
             'template_id' => $settings['template_id'] ?? '',
-            'persona' => $settings['persona'] ?? '',
-            'objective' => $settings['objective'] ?? '',
-            'length_tone' => $settings['length_tone'] ?? '',
-            'example' => $settings['example'] ?? '',
             'quick_replies' => isset($settings['quick_replies']) && is_array($settings['quick_replies']) ? array_values($settings['quick_replies']) : [],
             'forward_to_webhook' => !empty($settings['forward_to_webhook']),
         ],
@@ -182,10 +155,13 @@ function aicp_render_main_meta_box($post) {
         $pro_tab_classes .= ' aicp-pro-tab--locked';
     }
     ?>
-    <div id="aicp-tab-instructions" class="aicp-tab-content">
+    <div class="aicp-section-block" id="aicp-tab-instructions">
+        <h3><?php _e('Instrucciones y modelo', 'ai-chatbot-pro'); ?></h3>
+        <p class="description"><?php _e('Configura un único prompt maestro, elige el proveedor y el modelo, o aplica una de las plantillas de sistema incluidas.', 'ai-chatbot-pro'); ?></p>
         <?php aicp_render_instructions_tab($v); ?>
     </div>
-    <div id="aicp-tab-design" class="aicp-tab-content">
+    <div class="aicp-section-block" id="aicp-tab-design">
+        <h3><?php _e('Diseño y apariencia', 'ai-chatbot-pro'); ?></h3>
         <div class="aicp-design-layout">
             <div class="aicp-design-settings">
                 <?php aicp_render_design_tab($v); ?>
@@ -195,16 +171,19 @@ function aicp_render_main_meta_box($post) {
             </div>
         </div>
     </div>
-    <div id="aicp-tab-leads" class="<?php echo esc_attr($leads_tab_classes); ?>" data-forwarding-active="<?php echo $forwarding_active ? '1' : '0'; ?>">
+    <div class="aicp-section-block <?php echo esc_attr($leads_tab_classes); ?>" id="aicp-tab-leads" data-forwarding-active="<?php echo $forwarding_active ? '1' : '0'; ?>">
+        <h3><?php _e('Leads y conversaciones', 'ai-chatbot-pro'); ?></h3>
         <?php aicp_render_leads_tab($post->ID, $v); ?>
     </div>
-    <div id="aicp-tab-integrations" class="aicp-tab-content">
+    <div class="aicp-section-block" id="aicp-tab-integrations">
+        <h3><?php _e('Integraciones', 'ai-chatbot-pro'); ?></h3>
         <?php aicp_render_integrations_tab($post->ID, $v); ?>
     </div>
 
     <?php // Lógica corregida y limpia para mostrar el contenido PRO o el mensaje de venta.
     if (class_exists('AICP_Pro_Features')) : ?>
-        <div id="aicp-tab-pro" class="<?php echo esc_attr($pro_tab_classes); ?>" data-forwarding-active="<?php echo $forwarding_active ? '1' : '0'; ?>">
+        <div class="aicp-section-block <?php echo esc_attr($pro_tab_classes); ?>" id="aicp-tab-pro" data-forwarding-active="<?php echo $forwarding_active ? '1' : '0'; ?>">
+            <h3><?php _e('Funciones PRO', 'ai-chatbot-pro'); ?></h3>
             <div class="notice notice-warning inline aicp-pro-lock-notice"<?php echo $forwarding_active ? '' : ' style="display:none;"'; ?>>
                 <p><?php _e('La integración con webhook está activa. Desactívala para volver a entrenar el asistente o modificar estas opciones PRO.', 'ai-chatbot-pro'); ?></p>
             </div>
@@ -213,7 +192,8 @@ function aicp_render_main_meta_box($post) {
             ?>
         </div>
     <?php else: ?>
-        <div id="aicp-tab-pro-upsell" class="<?php echo esc_attr($pro_tab_classes); ?>" data-forwarding-active="<?php echo $forwarding_active ? '1' : '0'; ?>">
+        <div class="aicp-section-block <?php echo esc_attr($pro_tab_classes); ?>" id="aicp-tab-pro-upsell" data-forwarding-active="<?php echo $forwarding_active ? '1' : '0'; ?>">
+            <h3><?php _e('Funciones PRO', 'ai-chatbot-pro'); ?></h3>
             <?php aicp_render_pro_upsell(); ?>
         </div>
     <?php endif; ?>
@@ -223,6 +203,7 @@ function aicp_render_main_meta_box($post) {
 function aicp_render_instructions_tab($v) {
     $prompt = $v['master_prompt'] ?? '';
     $is_forwarding_enabled = !empty($v['forward_to_webhook']);
+    $selected_model    = $v['model'] ?? '';
     ?>
     <div class="notice notice-warning inline aicp-instructions-lock-notice"<?php echo $is_forwarding_enabled ? '' : ' style="display:none;"'; ?>>
         <p><?php _e('La integración con webhook está activa. Desactívala para volver a entrenar el asistente o modificar estas opciones PRO.', 'ai-chatbot-pro'); ?></p>
@@ -231,12 +212,12 @@ function aicp_render_instructions_tab($v) {
         <table class="form-table">
 
         <tr>
-            <th><label for="aicp_template_id"><?php _e('Plantilla de Asistente', 'ai-chatbot-pro'); ?></label></th>
+            <th><label for="aicp_template_id"><?php _e('Plantilla de System Prompt', 'ai-chatbot-pro'); ?></label></th>
             <td>
                 <select name="aicp_settings[template_id]" id="aicp_template_id" class="regular-text">
                     <option value=""><?php _e('Personalizado', 'ai-chatbot-pro'); ?></option>
                 </select>
-                <p class="description"><?php _e('Selecciona una plantilla predefinida para autocompletar los campos.', 'ai-chatbot-pro'); ?></p>
+                <p id="aicp_template_description" class="description"><?php _e('Selecciona una de las 10 plantillas incluidas para rellenar el prompt maestro al instante.', 'ai-chatbot-pro'); ?></p>
             </td>
         </tr>
         <tr>
@@ -252,20 +233,11 @@ function aicp_render_instructions_tab($v) {
             </td>
         </tr>
         <tr>
-            <th><label for="aicp_persona"><?php _e('Nombre y Personalidad', 'ai-chatbot-pro'); ?></label></th>
-            <td><textarea name="aicp_settings[persona]" id="aicp_persona" rows="3" class="large-text"><?php echo esc_textarea($v['persona'] ?? ''); ?></textarea></td>
-        </tr>
-        <tr>
-            <th><label for="aicp_objective"><?php _e('Objetivo Principal', 'ai-chatbot-pro'); ?></label></th>
-            <td><textarea name="aicp_settings[objective]" id="aicp_objective" rows="2" class="large-text"><?php echo esc_textarea($v['objective'] ?? ''); ?></textarea></td>
-        </tr>
-        <tr>
-            <th><label for="aicp_length_tone"><?php _e('Longitud y Tono', 'ai-chatbot-pro'); ?></label></th>
-            <td><textarea name="aicp_settings[length_tone]" id="aicp_length_tone" rows="3" class="large-text"><?php echo esc_textarea($v['length_tone'] ?? ''); ?></textarea></td>
-        </tr>
-        <tr>
-            <th><label for="aicp_example"><?php _e('Ejemplo de Respuesta', 'ai-chatbot-pro'); ?></label></th>
-            <td><textarea name="aicp_settings[example]" id="aicp_example" rows="5" class="large-text"><?php echo esc_textarea($v['example'] ?? ''); ?></textarea></td>
+            <th><label for="aicp_model"><?php _e('Modelo', 'ai-chatbot-pro'); ?></label></th>
+            <td>
+                <input type="text" name="aicp_settings[model]" id="aicp_model" class="regular-text" value="<?php echo esc_attr($selected_model); ?>" placeholder="<?php esc_attr_e('Ej: gpt-4o-mini, gemini-1.5-pro, llama3', 'ai-chatbot-pro'); ?>">
+                <p class="description"><?php _e('Introduce el nombre exacto del modelo que quieres usar en este asistente.', 'ai-chatbot-pro'); ?></p>
+            </td>
         </tr>
         <tr>
             <th><label><?php _e('Respuestas Rápidas', 'ai-chatbot-pro'); ?></label></th>
@@ -279,9 +251,8 @@ function aicp_render_instructions_tab($v) {
         <tr>
             <th><label for="aicp_custom_prompt"><?php _e('Prompt maestro (unificado)', 'ai-chatbot-pro'); ?></label></th>
             <td>
-                <label><input type="checkbox" id="aicp_edit_prompt_toggle"> <?php _e('Editar manualmente el prompt generado por la plantilla', 'ai-chatbot-pro'); ?></label>
                 <textarea name="aicp_settings[master_prompt]" id="aicp_custom_prompt" rows="12" class="large-text" placeholder="<?php esc_attr_e('El prompt maestro combina la plantilla y tus ajustes personalizados.', 'ai-chatbot-pro'); ?>"><?php echo esc_textarea($prompt); ?></textarea>
-                <p class="description"><?php _e('El prompt se genera a partir de la plantilla seleccionada y estos campos. Activa la casilla si quieres editarlo manualmente.', 'ai-chatbot-pro'); ?></p>
+                <p class="description"><?php _e('Escribe o pega aquí el prompt maestro definitivo que usará el chatbot. Puedes partir de una plantilla y después personalizarlo libremente.', 'ai-chatbot-pro'); ?></p>
             </td>
         </tr>
         </table>
@@ -367,6 +338,8 @@ function aicp_render_integrations_tab($assistant_id, $v) {
 }
 
 function aicp_render_leads_tab($assistant_id, $v) {
+    global $wpdb;
+
     $logs_table = $wpdb->prefix . 'aicp_chat_logs';
 
     echo '<p>' . __('El historial muestra las conversaciones y los datos estructurados capturados automáticamente. Los ajustes de leads se simplifican a los datos detectados dentro de cada conversación.', 'ai-chatbot-pro') . '</p>';
@@ -497,12 +470,9 @@ function aicp_save_meta_box_data($post_id) {
     if (!$lock_sections) {
         // Instrucciones
         $current['provider'] = isset($s['provider']) ? sanitize_key($s['provider']) : 'openai';
+        $current['model'] = isset($s['model']) ? sanitize_text_field($s['model']) : '';
         $current['master_prompt'] = isset($s['master_prompt']) ? wp_kses_post(wp_unslash($s['master_prompt'])) : '';
         $current['template_id'] = isset($s['template_id']) ? sanitize_text_field($s['template_id']) : '';
-        $current['persona'] = isset($s['persona']) ? sanitize_textarea_field($s['persona']) : '';
-        $current['objective'] = isset($s['objective']) ? sanitize_textarea_field($s['objective']) : '';
-        $current['length_tone'] = isset($s['length_tone']) ? sanitize_textarea_field($s['length_tone']) : '';
-        $current['example'] = isset($s['example']) ? sanitize_textarea_field($s['example']) : '';
         if (isset($s['quick_replies']) && is_array($s['quick_replies'])) {
             $current['quick_replies'] = array_values(array_filter(array_map('sanitize_text_field', $s['quick_replies'])));
         } else {

--- a/ai-chatbot-pro/admin/settings-page.php
+++ b/ai-chatbot-pro/admin/settings-page.php
@@ -55,6 +55,11 @@ function aicp_provider_openai_render() {
     <input type="text" name="aicp_model_providers[openai][model]" id="aicp_openai_model" value="<?php echo $model; ?>" class="regular-text" placeholder="gpt-4o" /></p>
     <p><label for="aicp_openai_base_url"><?php _e('URL alternativa', 'ai-chatbot-pro'); ?></label><br>
     <input type="url" name="aicp_model_providers[openai][base_url]" id="aicp_openai_base_url" value="<?php echo $base_url; ?>" class="regular-text" placeholder="https://tu-proxy/v1/chat/completions" /></p>
+    <div class="aicp-provider-test" data-provider="openai">
+        <button type="button" class="button button-secondary aicp-provider-test-button" data-provider="openai"><?php _e('Probar conexión con OpenAI', 'ai-chatbot-pro'); ?></button>
+        <span class="spinner" id="aicp_provider_openai_spinner"></span>
+        <div id="aicp_provider_openai_feedback" class="notice notice-alt inline aicp-provider-feedback" style="display:none;" aria-live="polite" role="status"></div>
+    </div>
     <?php
 }
 
@@ -74,6 +79,11 @@ function aicp_provider_gemini_render() {
     <input type="text" name="aicp_model_providers[gemini][model]" id="aicp_gemini_model" value="<?php echo $model; ?>" class="regular-text" placeholder="gemini-1.5-pro" /></p>
     <p><label for="aicp_gemini_endpoint"><?php _e('Ruta de endpoint', 'ai-chatbot-pro'); ?></label><br>
     <input type="url" name="aicp_model_providers[gemini][endpoint]" id="aicp_gemini_endpoint" value="<?php echo $endpoint; ?>" class="regular-text" placeholder="https://generativelanguage.googleapis.com/v1beta/" /></p>
+    <div class="aicp-provider-test" data-provider="gemini">
+        <button type="button" class="button button-secondary aicp-provider-test-button" data-provider="gemini"><?php _e('Probar conexión con Gemini', 'ai-chatbot-pro'); ?></button>
+        <span class="spinner" id="aicp_provider_gemini_spinner"></span>
+        <div id="aicp_provider_gemini_feedback" class="notice notice-alt inline aicp-provider-feedback" style="display:none;" aria-live="polite" role="status"></div>
+    </div>
     <?php
 }
 
@@ -99,6 +109,11 @@ function aicp_provider_custom_render() {
     <input type="number" step="0.1" name="aicp_model_providers[custom][temperature]" id="aicp_custom_temperature" value="<?php echo $temperature; ?>" class="small-text" /></p>
     <p><label for="aicp_custom_max_tokens"><?php _e('Máx. tokens (opcional)', 'ai-chatbot-pro'); ?></label><br>
     <input type="number" name="aicp_model_providers[custom][max_tokens]" id="aicp_custom_max_tokens" value="<?php echo $max_tokens; ?>" class="small-text" /></p>
+    <div class="aicp-provider-test" data-provider="custom">
+        <button type="button" class="button button-secondary aicp-provider-test-button" data-provider="custom"><?php _e('Probar conexión con el endpoint', 'ai-chatbot-pro'); ?></button>
+        <span class="spinner" id="aicp_provider_custom_spinner"></span>
+        <div id="aicp_provider_custom_feedback" class="notice notice-alt inline aicp-provider-feedback" style="display:none;" aria-live="polite" role="status"></div>
+    </div>
     <?php
 }
 
@@ -132,6 +147,31 @@ function aicp_render_settings_page() {
     </div>
     <?php
 }
+
+/**
+ * Encola scripts y estilos para la página de ajustes.
+ */
+function aicp_settings_admin_assets($hook) {
+    if ($hook !== 'aicp_assistant_page_aicp-settings') {
+        return;
+    }
+
+    wp_enqueue_style('aicp-admin-styles', AICP_PLUGIN_URL . 'assets/css/admin.css', [], AICP_VERSION);
+    wp_enqueue_script('aicp-settings-script', AICP_PLUGIN_URL . 'assets/js/settings.js', ['jquery'], AICP_VERSION, true);
+
+    wp_localize_script('aicp-settings-script', 'aicp_settings_params', [
+        'ajax_url' => admin_url('admin-ajax.php'),
+        'nonce'    => wp_create_nonce('aicp_test_model_nonce'),
+        'labels'   => [
+            'checking' => __('Comprobando la conexión...', 'ai-chatbot-pro'),
+            'success'  => __('Conexión verificada correctamente.', 'ai-chatbot-pro'),
+            'error'    => __('No se pudo verificar la conexión. Revisa la configuración e inténtalo de nuevo.', 'ai-chatbot-pro'),
+            'preview'  => __('Respuesta del modelo', 'ai-chatbot-pro'),
+            'missing'  => __('Rellena el modelo y los campos obligatorios antes de probar.', 'ai-chatbot-pro'),
+        ],
+    ]);
+}
+add_action('admin_enqueue_scripts', 'aicp_settings_admin_assets');
 
 /**
  * Sanitiza las opciones de ajustes generales.

--- a/ai-chatbot-pro/assets/css/admin.css
+++ b/ai-chatbot-pro/assets/css/admin.css
@@ -2,27 +2,24 @@
  * Estilos para el panel de administración de AI Chatbot Pro
  */
 
-/* Pestañas */
-.aicp-nav-tab-wrapper { margin-bottom: -1px; }
-.aicp-tab-content { margin-top: 1em; }
+/* Contenedores apilados */
+.aicp-section-block {
+    background: #fff;
+    border: 1px solid #dcdcde;
+    border-radius: 6px;
+    padding: 20px;
+    margin-bottom: 20px;
+}
+.aicp-section-block h3 { margin-top: 0; }
+.aicp-section-block .description { margin-top: 4px; margin-bottom: 12px; }
+.aicp-tab-content {
+    margin-top: 1em;
+    display: block;
+}
 .aicp-pro-tag {
     display: inline-block; background-color: #ffba00; color: #000;
     font-size: 9px; font-weight: bold; padding: 2px 6px;
     border-radius: 3px; margin-left: 5px; vertical-align: middle;
-}
-.aicp-nav-tab-wrapper .aicp-nav-tab--disabled {
-    color: #a0a5aa;
-    border-color: #dcdcde;
-    background: #f6f7f7;
-    cursor: not-allowed;
-}
-.aicp-nav-tab-wrapper .aicp-nav-tab--disabled:hover,
-.aicp-nav-tab-wrapper .aicp-nav-tab--disabled:focus {
-    color: #a0a5aa;
-    box-shadow: none;
-}
-.aicp-nav-tab-wrapper .aicp-nav-tab--disabled.nav-tab-active {
-    border-bottom-color: #dcdcde;
 }
 .aicp-pro-feature-wrapper { background-color: #fff; border: 1px solid #ddd; padding: 20px; text-align: center; }
 
@@ -237,4 +234,17 @@
 #aicp_test_webhook_feedback .aicp-webhook-feedback-details table.widefat td,
 #aicp_test_webhook_feedback .aicp-webhook-feedback-details table.widefat th {
     word-break: break-word;
+}
+
+.aicp-provider-test {
+    margin-top: 12px;
+}
+
+.aicp-provider-test .spinner {
+    float: none;
+    margin: 0 8px 0 6px;
+}
+
+.aicp-provider-feedback {
+    margin-top: 10px;
 }

--- a/ai-chatbot-pro/assets/js/admin-scripts.js
+++ b/ai-chatbot-pro/assets/js/admin-scripts.js
@@ -6,7 +6,6 @@ jQuery(function($) {
     window.aicp_admin_params = window.aicp_admin_params || {};
     const leadFieldDefinitions = aicp_admin_params.lead_fields || {};
     const escapeHtml = (text) => $('<div/>').text(text == null ? '' : String(text)).html();
-    const navLockMessage = aicp_admin_params.webhook_lock_message || '';
 
     const formatPreformatted = (value) => {
         return `<pre class="aicp-webhook-code-block">${escapeHtml(value == null ? '' : String(value))}</pre>`;
@@ -63,24 +62,6 @@ jQuery(function($) {
         return `<table class="widefat fixed striped"><tbody>${rows.join('')}</tbody></table>`;
     };
 
-    function setNavTabsLock(locked) {
-        const $tabs = $('.aicp-nav-tab-wrapper [data-lockable-tab="1"]');
-        $tabs.each(function() {
-            const $tab = $(this);
-            if (locked) {
-                $tab.addClass('aicp-nav-tab--disabled')
-                    .attr('aria-disabled', 'true')
-                    .attr('data-tab-disabled', '1')
-                    .data('tabDisabled', 1);
-            } else {
-                $tab.removeClass('aicp-nav-tab--disabled')
-                    .removeAttr('aria-disabled')
-                    .removeAttr('data-tab-disabled')
-                    .removeData('tabDisabled');
-            }
-        });
-    }
-
     // Inicializar color pickers
     $('.aicp-color-picker').wpColorPicker({
         change: function(event, ui) {
@@ -91,28 +72,6 @@ jQuery(function($) {
         }
     });
 
-    function handleTabs() {
-        $('.aicp-nav-tab-wrapper a').on('click', function(e) {
-            const $tab = $(this);
-            const isDisabled = $tab.attr('aria-disabled') === 'true' || $tab.data('tabDisabled') === 1;
-            if (isDisabled) {
-                e.preventDefault();
-                if (navLockMessage) {
-                    window.alert(navLockMessage);
-                }
-                return;
-            }
-
-            e.preventDefault();
-            $('.aicp-nav-tab-wrapper a').removeClass('nav-tab-active');
-            $tab.addClass('nav-tab-active');
-            $('.aicp-tab-content').hide();
-            const targetTab = $tab.attr('href');
-            $(targetTab).show();
-        });
-        $('.aicp-tab-content').not(':first').hide();
-    }
-    
     function handleMediaUploader() {
         let mediaUploader;
         $(document).on('click', '.aicp-upload-button', function(e) {
@@ -549,20 +508,6 @@ jQuery(function($) {
         });
     }
 
-    function handleCustomPromptToggle() {
-        const $textarea = $('#aicp_custom_prompt');
-        const $toggle = $('#aicp_edit_prompt_toggle');
-        function refresh() {
-            if ($toggle.is(':checked')) {
-                $textarea.prop('readonly', false);
-            } else {
-                $textarea.prop('readonly', true);
-            }
-        }
-        $toggle.on('change', refresh);
-        refresh();
-    }
-
     function handleWebhookToggle() {
         const $toggle = $('#aicp_forward_to_webhook');
         if (!$toggle.length) return;
@@ -649,8 +594,6 @@ jQuery(function($) {
                 $notice.hide();
             }
 
-            setNavTabsLock(locked);
-
             $lockableElements.each(function() {
                 const $el = $(this);
                 if ($el.hasClass('aicp-lock-hidden')) return;
@@ -669,8 +612,6 @@ jQuery(function($) {
         const initialLocked = $toggle.is(':checked') || !!(aicp_admin_params.initial_settings && aicp_admin_params.initial_settings.forward_to_webhook);
         if (initialLocked) {
             setLockedState(true);
-        } else {
-            setNavTabsLock(false);
         }
     }
 
@@ -1150,105 +1091,78 @@ jQuery(function($) {
         $('#aicp_position').on('change', function() { $('#aicp-preview-chatbot-container').removeClass('position-br position-bl').addClass('position-' + $(this).val()); });
     }
 
-    function initTemplateSelector() {
+    
+function initTemplateSelector() {
         if (typeof loadAssistantTemplates !== 'function') return;
 
-        const promptFields = ['persona', 'objective', 'length_tone', 'example'];
-        const $quickReplies = $('input[name="aicp_settings[quick_replies][]"]');
         const $compiledPrompt = $('#aicp_custom_prompt');
         const $select = $('#aicp_template_id');
+        const $description = $('#aicp_template_description');
+        const $quickReplies = $('input[name="aicp_settings[quick_replies][]"]');
+        const meta = aicp_admin_params.meta || {};
         let templates = [];
 
-        // Función que recompila el prompt final basándose en los campos del formulario
-        const recompilePrompt = () => {
-            const settings = {
-                template_id: $select.val(),
-                persona: $('#aicp_persona').val(),
-                objective: $('#aicp_objective').val(),
-                length_tone: $('#aicp_length_tone').val(),
-                example: $('#aicp_example').val()
-            };
-
-            const template = templates.find(t => t.id === settings.template_id);
-            let prompt = '';
-
-            if (template) {
-                prompt = window.renderTemplate(template.system_prompt_template, aicp_admin_params.meta);
-
-                if (settings.persona) prompt += `\n\nPERSONALIDAD: ${settings.persona}`;
-                if (settings.objective) prompt += `\n\nOBJETIVO PRINCIPAL: ${settings.objective}`;
-                if (settings.length_tone) prompt += `\n\nTONO Y LONGITUD: ${settings.length_tone}`;
-                if (settings.example) prompt += `\n\nEJEMPLO DE RESPUESTA: ${settings.example}`;
+        const renderDescription = (template) => {
+            if ($description.length === 0) {
+                return;
             }
 
-            if (!prompt) {
-                prompt = 'Eres un asistente de IA.';
+            if (!template) {
+                $description.text(aicp_admin_params.template_description_fallback || '');
+                return;
             }
 
-            $compiledPrompt.val(prompt);
+            const pieces = [template.label];
+            if (template.description) {
+                pieces.push(template.description);
+            }
+
+            $description.text(pieces.join(' — '));
         };
 
-        // Función para rellenar los campos con los datos de una plantilla
-        const fillFormWithTemplate = (tmpl) => {
-            if (tmpl) {
-                // Mapeo explícito y directo de cada campo
-                $('#aicp_persona').val(tmpl.persona || '');
-                $('#aicp_objective').val(tmpl.objective || '');
-                $('#aicp_length_tone').val(tmpl.length_tone || '');
-                $('#aicp_example').val(tmpl.example || '');
+        const applyTemplate = (template, force = false) => {
+            renderDescription(template);
 
-                const qrData = tmpl.quick_replies || [];
-                $quickReplies.each(function(index) {
-                    $(this).val(qrData[index] || '');
-                });
-
-                $('#aicp_edit_prompt_toggle').prop('checked', false);
-            } else {
-                promptFields.forEach(field => $(`#aicp_${field}`).val(''));
-                $quickReplies.val('');
-                $('#aicp_edit_prompt_toggle').prop('checked', false);
+            if (!template || !template.system_prompt_template) {
+                return;
             }
-            recompilePrompt();
+
+            const rendered = window.renderTemplate(template.system_prompt_template, meta);
+
+            if (force || !$compiledPrompt.val().trim()) {
+                $compiledPrompt.val(rendered);
+            }
+
+            if (template.quick_replies && Array.isArray(template.quick_replies) && $quickReplies.length) {
+                $quickReplies.each(function(index) {
+                    if (force || !$(this).val()) {
+                        $(this).val(template.quick_replies[index] || '');
+                    }
+                });
+            }
         };
 
         window.loadAssistantTemplates(aicp_admin_params.templates_url).then((data) => {
-            templates = data;
+            templates = Array.isArray(data) ? data : [];
             templates.forEach(t => {
                 $select.append(`<option value="${t.id}">${t.label}</option>`);
             });
 
             const initialTemplateId = aicp_admin_params.initial_settings.template_id || '';
-            $select.val(initialTemplateId);
-            const initialTemplate = templates.find(t => t.id === initialTemplateId);
-            if (initialTemplate) {
-                fillFormWithTemplate(initialTemplate);
-                promptFields.forEach(field => $(`#aicp_${field}`).val(aicp_admin_params.initial_settings[field] || $(`#aicp_${field}`).val()));
-                $quickReplies.each(function(index) {
-                    $(this).val(aicp_admin_params.initial_settings.quick_replies[index] || $(this).val());
-                });
+            if (initialTemplateId) {
+                $select.val(initialTemplateId);
             }
-            recompilePrompt();
+
+            const initialTemplate = templates.find(t => t.id === initialTemplateId);
+            applyTemplate(initialTemplate, false);
 
             $select.on('change', function() {
                 const tmpl = templates.find(t => t.id === this.value);
-                fillFormWithTemplate(tmpl);
-            });
-
-            promptFields.forEach(field => {
-                $(`#aicp_${field}`).on('input', recompilePrompt);
-            });
-
-            $quickReplies.on('input', recompilePrompt);
-
-            $('#aicp_edit_prompt_toggle').on('change', function() {
-                if (this.checked) {
-                    recompilePrompt();
-                }
+                applyTemplate(tmpl, true);
             });
         });
     }
     if ($('body').hasClass('post-type-aicp_assistant')) {
-        handleTabs();
         handleMediaUploader();
         handleHistoryModal();
         handleDeleteLogFromModal();
@@ -1256,7 +1170,6 @@ jQuery(function($) {
         initLivePreview();
         handleDeleteLogFromList();
         initTemplateSelector();
-        handleCustomPromptToggle();
         handleWebhookTestButton();
         handleWebhookToggle();
         handleLeadsLock();

--- a/ai-chatbot-pro/assets/js/settings.js
+++ b/ai-chatbot-pro/assets/js/settings.js
@@ -1,0 +1,145 @@
+jQuery(function($) {
+    const params = window.aicp_settings_params || {};
+
+    const getLabel = (key, fallback) => {
+        if (params.labels && Object.prototype.hasOwnProperty.call(params.labels, key)) {
+            return params.labels[key];
+        }
+        return fallback;
+    };
+
+    function resetFeedback($container) {
+        $container
+            .removeClass('notice-success notice-error notice-info notice-warning')
+            .attr('role', 'status')
+            .attr('aria-live', 'polite')
+            .hide()
+            .empty();
+    }
+
+    function showFeedback($container, type, html) {
+        const classes = ['notice', 'notice-alt', 'inline'];
+        let role = 'status';
+        let live = 'polite';
+
+        if (type === 'success') {
+            classes.push('notice-success');
+        } else if (type === 'error') {
+            classes.push('notice-error');
+            role = 'alert';
+            live = 'assertive';
+        } else {
+            classes.push('notice-info');
+        }
+
+        $container
+            .removeClass('notice-success notice-error notice-info notice-warning')
+            .addClass(classes.join(' '))
+            .attr('role', role)
+            .attr('aria-live', live)
+            .html(html)
+            .show();
+
+        const spoken = $container.text();
+        if (spoken && window.wp && wp.a11y && typeof wp.a11y.speak === 'function') {
+            wp.a11y.speak(spoken, live === 'assertive' ? 'assertive' : 'polite');
+        }
+    }
+
+    function buildPayload(provider) {
+        const payload = {
+            action: 'aicp_test_model_connection',
+            nonce: params.nonce || '',
+            provider,
+        };
+
+        switch (provider) {
+            case 'openai':
+                payload.api_key = $('#aicp_openai_api_key').val() || '';
+                payload.model = $('#aicp_openai_model').val() || '';
+                payload.base_url = $('#aicp_openai_base_url').val() || '';
+                break;
+            case 'gemini':
+                payload.api_key = $('#aicp_gemini_api_key').val() || '';
+                payload.model = $('#aicp_gemini_model').val() || '';
+                payload.endpoint = $('#aicp_gemini_endpoint').val() || '';
+                break;
+            case 'custom':
+                payload.api_key = $('#aicp_custom_api_key').val() || '';
+                payload.model = $('#aicp_custom_model').val() || '';
+                payload.endpoint = $('#aicp_custom_endpoint').val() || '';
+                payload.temperature = $('#aicp_custom_temperature').val() || '';
+                payload.max_tokens = $('#aicp_custom_max_tokens').val() || '';
+                break;
+            default:
+                break;
+        }
+
+        return payload;
+    }
+
+    function hasRequiredFields(provider, payload) {
+        if (!payload.model) {
+            return false;
+        }
+
+        if (provider === 'gemini') {
+            return !!(payload.api_key && payload.endpoint);
+        }
+        if (provider === 'openai') {
+            return !!payload.api_key;
+        }
+        if (provider === 'custom') {
+            return !!payload.endpoint;
+        }
+
+        return false;
+    }
+
+    $('.aicp-provider-test-button').on('click', function(event) {
+        event.preventDefault();
+        const provider = $(this).data('provider');
+        const $wrapper = $(this).closest('.aicp-provider-test');
+        const $spinner = $wrapper.find('.spinner');
+        const $feedback = $wrapper.find('.aicp-provider-feedback');
+        const payload = buildPayload(provider);
+
+        resetFeedback($feedback);
+
+        if (!hasRequiredFields(provider, payload)) {
+            showFeedback($feedback, 'error', `<p>${getLabel('missing', 'Rellena los campos obligatorios antes de probar.')}</p>`);
+            return;
+        }
+
+        $spinner.addClass('is-active');
+        $(this).prop('disabled', true);
+
+        const checkingMsg = getLabel('checking', 'Comprobando la conexión...');
+        showFeedback($feedback, 'info', `<p>${checkingMsg}</p>`);
+
+        $.ajax({
+            method: 'POST',
+            url: params.ajax_url,
+            dataType: 'json',
+            data: payload,
+        }).done((response) => {
+            if (response && response.success) {
+                const data = response.data || {};
+                const successMsg = getLabel('success', 'Conexión verificada correctamente.');
+                const previewLabel = getLabel('preview', 'Respuesta del modelo');
+                const preview = data.preview ? `<p><strong>${previewLabel}:</strong></p><p>${data.preview}</p>` : '';
+                showFeedback($feedback, 'success', `<p>${successMsg}</p>${preview}`);
+            } else {
+                const data = (response && response.data) || {};
+                const message = data.message || getLabel('error', 'No se pudo verificar la conexión. Revisa la configuración e inténtalo de nuevo.');
+                showFeedback($feedback, 'error', `<p>${message}</p>`);
+            }
+        }).fail(() => {
+            const failMessage = getLabel('error', 'No se pudo verificar la conexión. Revisa la configuración e inténtalo de nuevo.');
+            showFeedback($feedback, 'error', `<p>${failMessage}</p>`);
+        }).always(() => {
+            $spinner.removeClass('is-active');
+            $('.aicp-provider-test-button').prop('disabled', false);
+        });
+    });
+});

--- a/ai-chatbot-pro/includes/class-ajax-handler.php
+++ b/ai-chatbot-pro/includes/class-ajax-handler.php
@@ -20,6 +20,7 @@ class AICP_Ajax_Handler {
         add_action('wp_ajax_aicp_delete_log', [__CLASS__, 'handle_delete_log']);
         add_action('wp_ajax_aicp_get_log_details', [__CLASS__, 'handle_get_log_details']);
         add_action('wp_ajax_aicp_test_webhook', [__CLASS__, 'handle_test_webhook']); // Para probar webhook desde admin
+        add_action('wp_ajax_aicp_test_model_connection', [__CLASS__, 'handle_test_model_connection']);
         add_action('wp_ajax_aicp_get_templates', [__CLASS__, 'handle_get_templates']); // Para cargar plantillas en admin
 
         // Hooks de feedback
@@ -389,6 +390,94 @@ class AICP_Ajax_Handler {
             if (isset($result['duration'])) $response['duration'] = floatval($result['duration']);
             wp_send_json_success($response);
         }
+    }
+
+
+    /**
+     * Maneja la prueba de conexión con proveedores de modelo desde la pantalla de ajustes.
+     */
+    public static function handle_test_model_connection() {
+        check_ajax_referer('aicp_test_model_nonce', 'nonce');
+
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(['message' => __('No tienes permisos para realizar esta acción.', 'ai-chatbot-pro')]);
+        }
+
+        $provider = isset($_POST['provider']) ? sanitize_key(wp_unslash($_POST['provider'])) : '';
+        if ($provider === '') {
+            wp_send_json_error(['message' => __('Selecciona un proveedor para probar la conexión.', 'ai-chatbot-pro')]);
+        }
+
+        $settings = [
+            'api_key' => isset($_POST['api_key']) ? sanitize_text_field(wp_unslash($_POST['api_key'])) : '',
+            'model'   => isset($_POST['model']) ? sanitize_text_field(wp_unslash($_POST['model'])) : '',
+        ];
+
+        if (isset($_POST['base_url'])) {
+            $settings['base_url'] = esc_url_raw(wp_unslash($_POST['base_url']));
+        }
+        if (isset($_POST['endpoint'])) {
+            $settings['endpoint'] = esc_url_raw(wp_unslash($_POST['endpoint']));
+        }
+        if (isset($_POST['temperature']) && $_POST['temperature'] !== '') {
+            $settings['temperature'] = floatval(wp_unslash($_POST['temperature']));
+        }
+        if (isset($_POST['max_tokens']) && $_POST['max_tokens'] !== '') {
+            $settings['max_tokens'] = intval(wp_unslash($_POST['max_tokens']));
+        }
+
+        $missing_fields = false;
+        switch ($provider) {
+            case 'gemini':
+                $missing_fields = empty($settings['api_key']) || empty($settings['model']) || empty($settings['endpoint']);
+                break;
+            case 'custom':
+                $missing_fields = empty($settings['model']) || empty($settings['endpoint']);
+                break;
+            default:
+                $missing_fields = empty($settings['api_key']) || empty($settings['model']);
+                break;
+        }
+
+        if ($missing_fields) {
+            wp_send_json_error(['message' => __('Rellena todos los campos obligatorios antes de probar.', 'ai-chatbot-pro')]);
+        }
+
+        if (!class_exists('AICP_Model_Router')) {
+            require_once AICP_PLUGIN_DIR . 'includes/class-model-router.php';
+        }
+
+        $driver = AICP_Model_Router::get_driver($provider);
+        if (!$driver || !method_exists($driver, 'send_message')) {
+            wp_send_json_error(['message' => __('No se pudo inicializar el driver del modelo.', 'ai-chatbot-pro')]);
+        }
+
+        $prompt  = __('Prueba de conexión desde el panel de ajustes.', 'ai-chatbot-pro');
+        $history = [
+            ['role' => 'user', 'content' => __('Mensaje de verificación rápida para comprobar la API.', 'ai-chatbot-pro')],
+        ];
+
+        $response = $driver->send_message($prompt, $history, $settings);
+
+        if (is_wp_error($response)) {
+            $error_message = $response->get_error_message();
+            $error_code    = $response->get_error_code();
+            $payload       = ['message' => $error_message];
+            if (!empty($error_code)) {
+                $payload['code'] = $error_code;
+            }
+            wp_send_json_error($payload);
+        }
+
+        $preview = '';
+        if (is_string($response) && $response !== '') {
+            $preview = wp_strip_all_tags(wp_html_excerpt($response, 240, '…'));
+        }
+
+        wp_send_json_success([
+            'message' => __('Conexión verificada correctamente.', 'ai-chatbot-pro'),
+            'preview' => $preview,
+        ]);
     }
 
 


### PR DESCRIPTION
## Summary
- remove admin tab navigation and present assistant settings as stacked section blocks
- simplify instructions to a single master prompt with model selection and template-based autofill
- refresh admin styles and template loader so prompt templates populate descriptions and quick replies
- add provider connection test controls on the settings page to validate API and model credentials

## Testing
- php -l ai-chatbot-pro/admin/settings-page.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921f98b01788330965dab2d2b714d99)